### PR TITLE
Rename WorkspaceProperties to WorkspaceContext

### DIFF
--- a/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
@@ -40,6 +40,7 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
+          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
           type: object
         spec:
           description: Desired state of the workspace

--- a/pkg/apis/workspace/v1alpha1/workspace_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspace_types.go
@@ -30,7 +30,11 @@ import (
 // +kubebuilder:printcolumn:name=Status,type=string,JSONPath=.status.phase
 // +kubebuilder:printcolumn:name=Url,type=string,JSONPath=.status.ideUrl
 type Workspace struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Desired state of the workspace

--- a/pkg/controller/modelutils/k8s/ingress.go
+++ b/pkg/controller/modelutils/k8s/ingress.go
@@ -3,6 +3,6 @@ package utils
 import "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
 import "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 
-func IngressHostName(name string, wkspProperties model.WorkspaceProperties) string {
-	return name + "-" + wkspProperties.Namespace + "." + config.ControllerCfg.GetIngressGlobalDomain()
+func IngressHostName(name string, wkspCtx model.WorkspaceContext) string {
+	return name + "-" + wkspCtx.Namespace + "." + config.ControllerCfg.GetIngressGlobalDomain()
 }

--- a/pkg/controller/workspace/component/envs.go
+++ b/pkg/controller/workspace/component/envs.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
 )
 
-func commonEnvironmentVariables(wkspProps WorkspaceProperties) []corev1.EnvVar {
+func commonEnvironmentVariables(wkspCtx WorkspaceContext) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name: "CHE_MACHINE_TOKEN",
@@ -29,7 +29,7 @@ func commonEnvironmentVariables(wkspProps WorkspaceProperties) []corev1.EnvVar {
 		},
 		{
 			Name:  "CHE_API",
-			Value: wkspProps.CheApiExternal,
+			Value: wkspCtx.CheApiExternal,
 		},
 		{
 			Name:  "CHE_API_INTERNAL",
@@ -37,15 +37,15 @@ func commonEnvironmentVariables(wkspProps WorkspaceProperties) []corev1.EnvVar {
 		},
 		{
 			Name:  "CHE_API_EXTERNAL",
-			Value: wkspProps.CheApiExternal,
+			Value: wkspCtx.CheApiExternal,
 		},
 		{
 			Name:  "CHE_WORKSPACE_NAME",
-			Value: wkspProps.WorkspaceName,
+			Value: wkspCtx.WorkspaceName,
 		},
 		{
 			Name:  "CHE_WORKSPACE_ID",
-			Value: wkspProps.WorkspaceId,
+			Value: wkspCtx.WorkspaceId,
 		},
 		{
 			Name:  "CHE_AUTH_ENABLED",
@@ -53,7 +53,7 @@ func commonEnvironmentVariables(wkspProps WorkspaceProperties) []corev1.EnvVar {
 		},
 		{
 			Name:  "CHE_WORKSPACE_NAMESPACE",
-			Value: wkspProps.Namespace,
+			Value: wkspCtx.Namespace,
 		},
 	}
 }

--- a/pkg/controller/workspace/model/context.go
+++ b/pkg/controller/workspace/model/context.go
@@ -12,7 +12,7 @@
 
 package model
 
-type WorkspaceProperties struct {
+type WorkspaceContext struct {
 	WorkspaceId    string
 	WorkspaceName  string
 	Namespace      string

--- a/pkg/controller/workspace/status.go
+++ b/pkg/controller/workspace/status.go
@@ -185,8 +185,8 @@ func (r *ReconcileWorkspace) updateStatusAfterWorkspaceChange(rs *reconcileStatu
 			clearCondition(&rs.workspace.Status, workspacev1alpha1.WorkspaceConditionStopped)
 			modifiedStatus = true
 		}
-		if rs.wkspProps != nil {
-			if rs.wkspProps.Started {
+		if rs.wkspCtx != nil {
+			if rs.wkspCtx.Started {
 				if rs.changedWorkspaceObjects || rs.createdWorkspaceObjects {
 					clearCondition(&rs.workspace.Status, workspacev1alpha1.WorkspaceConditionStopped)
 					rs.workspace.Status.Phase = workspacev1alpha1.WorkspacePhaseStarting
@@ -210,7 +210,7 @@ func (r *ReconcileWorkspace) updateStatusAfterWorkspaceChange(rs *reconcileStatu
 				}
 			}
 			if modifiedStatus {
-				rs.workspace.Status.WorkspaceId = rs.wkspProps.WorkspaceId
+				rs.workspace.Status.WorkspaceId = rs.wkspCtx.WorkspaceId
 			}
 		}
 


### PR DESCRIPTION
It contains a few changes:
1. Add a standard description for object's metadata
2. Rename WorkspaceProperties to WorkspaceContext. In general, I wonder if we can get rid of such helper object at all, but will see.

It's done in a scope of https://github.com/eclipse/che/issues/15783