### PR TITLE
Trim ingress hostnames to 63 chars to make sure domain is valid

### DIFF
--- a/pkg/controller/modelutils/k8s/ingress.go
+++ b/pkg/controller/modelutils/k8s/ingress.go
@@ -1,8 +1,20 @@
 package utils
 
-import "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
-import "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
+import (
+	"fmt"
+	"strconv"
 
-func IngressHostName(name string, wkspCtx model.WorkspaceContext) string {
-	return name + "-" + wkspCtx.Namespace + "." + config.ControllerCfg.GetIngressGlobalDomain()
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
+)
+
+// IngressHostname generates a hostname based on service name and namespace
+func IngressHostname(serviceName, namespace string, port int64) string {
+	ingressName := IngressName(serviceName, port)
+	return fmt.Sprintf("%s-%s.%s", ingressName, namespace, config.ControllerCfg.GetIngressGlobalDomain())
+}
+
+// IngressName genereates a names for ingresses
+func IngressName(serviceName string, port int64) string {
+	portString := strconv.FormatInt(port, 10)
+	return serviceName + "-" + portString
 }

--- a/pkg/controller/modelutils/k8s/ingress.go
+++ b/pkg/controller/modelutils/k8s/ingress.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 )
@@ -10,10 +11,14 @@ import (
 // IngressHostname generates a hostname based on service name and namespace
 func IngressHostname(serviceName, namespace string, port int64) string {
 	ingressName := IngressName(serviceName, port)
-	return fmt.Sprintf("%s-%s.%s", ingressName, namespace, config.ControllerCfg.GetIngressGlobalDomain())
+	hostname := fmt.Sprintf("%s-%s", ingressName, namespace)
+	if len(hostname) > 63 {
+		hostname = strings.TrimSuffix(hostname[:63], "-")
+	}
+	return fmt.Sprintf("%s.%s", hostname, config.ControllerCfg.GetIngressGlobalDomain())
 }
 
-// IngressName genereates a names for ingresses
+// IngressName generates a names for ingresses
 func IngressName(serviceName string, port int64) string {
 	portString := strconv.FormatInt(port, 10)
 	return serviceName + "-" + portString

--- a/pkg/controller/modelutils/k8s/service.go
+++ b/pkg/controller/modelutils/k8s/service.go
@@ -13,15 +13,25 @@
 package utils
 
 import (
+	"strconv"
+	"strings"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"strconv"
 )
 
-func ServicePortName(port int) string {
-	return "srv-" + strconv.FormatInt(int64(port), 10)
+// ContainerServiceName generates service names for workspaces
+func ContainerServiceName(workspaceId, containerName string) string {
+	return "server" + strings.ReplaceAll(workspaceId, "workspace", "") + "-" + containerName
 }
 
+// ServicePortName generates names for ports in workspace services
+func ServicePortName(port int) string {
+	return "server-" + strconv.FormatInt(int64(port), 10)
+}
+
+// BuildServicePorts converts exposed ports into k8s ServicePort objects
 func BuildServicePorts(exposedPorts []int, protocol corev1.Protocol) []corev1.ServicePort {
 	var servicePorts []corev1.ServicePort
 	for _, port := range exposedPorts {
@@ -33,4 +43,13 @@ func BuildServicePorts(exposedPorts []int, protocol corev1.Protocol) []corev1.Se
 		})
 	}
 	return servicePorts
+}
+
+// EndpointPortsToInts converts model endpoints to ints
+func EndpointPortsToInts(endpoints []v1alpha1.Endpoint) []int {
+	ports := []int{}
+	for _, endpoint := range endpoints {
+		ports = append(ports, int(endpoint.Port))
+	}
+	return ports
 }

--- a/pkg/controller/workspace/component/converter.go
+++ b/pkg/controller/workspace/component/converter.go
@@ -14,8 +14,10 @@ package component
 
 import (
 	"errors"
-	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/server"
 	"strings"
+
+	modelutils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/server"
 
 	workspaceApi "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
@@ -250,7 +252,7 @@ func buildWorkspaceRouting(wkspCtx WorkspaceContext, componentInstanceStatuses [
 			}
 			if len(containerEndpoints) > 0 {
 				services[containerName] = workspaceApi.ServiceDescription{
-					ServiceName: containerServiceName(wkspCtx, containerName),
+					ServiceName: modelutils.ContainerServiceName(wkspCtx.WorkspaceId, containerName),
 					Endpoints:   containerEndpoints,
 				}
 			}

--- a/pkg/controller/workspace/component/dockerimage.go
+++ b/pkg/controller/workspace/component/dockerimage.go
@@ -13,14 +13,15 @@
 package component
 
 import (
-	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/server"
-	"github.com/eclipse/che-plugin-broker/model"
 	"regexp"
 	"strconv"
 	"strings"
 
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/server"
+	"github.com/eclipse/che-plugin-broker/model"
+
 	workspaceApi "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
-	k8sModelUtils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
+	modelutils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +49,7 @@ func setupDockerimageComponent(wkspCtx WorkspaceContext, commands []workspaceApi
 		containerName = component.Alias
 	}
 
-	var exposedPorts []int = endpointPortsToInts(component.Endpoints)
+	var exposedPorts []int = modelutils.EndpointPortsToInts(component.Endpoints)
 
 	var limitOrDefault string
 
@@ -80,7 +81,7 @@ func setupDockerimageComponent(wkspCtx WorkspaceContext, commands []workspaceApi
 		Name:            containerName,
 		Image:           *component.Image,
 		ImagePullPolicy: corev1.PullPolicy(ControllerCfg.GetSidecarPullPolicy()),
-		Ports:           k8sModelUtils.BuildContainerPorts(exposedPorts, corev1.ProtocolTCP),
+		Ports:           modelutils.BuildContainerPorts(exposedPorts, corev1.ProtocolTCP),
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				"memory": limit,

--- a/pkg/controller/workspace/component/utilities.go
+++ b/pkg/controller/workspace/component/utilities.go
@@ -13,12 +13,13 @@
 package component
 
 import (
-	k8sModelUtils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
+	"strings"
+
+	modelutils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
 	config "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 	"github.com/eclipse/che-plugin-broker/model"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 
 	workspaceApi "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
@@ -29,18 +30,6 @@ func emptyIfNil(s *string) string {
 		return *s
 	}
 	return ""
-}
-
-func containerServiceName(wkspCtx WorkspaceContext, containerName string) string {
-	return "server" + strings.ReplaceAll(wkspCtx.WorkspaceId, "workspace", "") + "-" + containerName
-}
-
-func endpointPortsToInts(endpoints []workspaceApi.Endpoint) []int {
-	ports := []int{}
-	for _, endpint := range endpoints {
-		ports = append(ports, int(endpint.Port))
-	}
-	return ports
 }
 
 func createVolumeMounts(wkspCtx WorkspaceContext, mountSources *bool, devfileVolumes []workspaceApi.Volume, pluginVolumes []model.Volume) []corev1.VolumeMount {
@@ -75,8 +64,8 @@ func createVolumeMounts(wkspCtx WorkspaceContext, mountSources *bool, devfileVol
 
 func createK8sServicesForContainers(wkspCtx WorkspaceContext, containerName string, exposedPorts []int) []corev1.Service {
 	services := []corev1.Service{}
-	servicePorts := k8sModelUtils.BuildServicePorts(exposedPorts, corev1.ProtocolTCP)
-	serviceName := containerServiceName(wkspCtx, containerName)
+	servicePorts := modelutils.BuildServicePorts(exposedPorts, corev1.ProtocolTCP)
+	serviceName := modelutils.ContainerServiceName(wkspCtx.WorkspaceId, containerName)
 	if len(servicePorts) > 0 {
 		service := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/workspace/server/che_rest_apis.go
+++ b/pkg/controller/workspace/server/che_rest_apis.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"fmt"
+
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
 )
@@ -56,8 +57,8 @@ func AddCheRestApis(wkspCtx WorkspaceContext, podSpec *corev1.PodSpec) ([]runtim
 	})
 
 	serviceName, servicePort := containerName, k8sModelUtils.ServicePortName(cheRestApisPort)
-	serviceNameAndPort := serviceName + "-" + servicePort
-	ingressHost := k8sModelUtils.IngressHostName(serviceNameAndPort, wkspCtx)
+	ingressName := k8sModelUtils.IngressName(serviceName, int64(cheRestApisPort))
+	ingressHost := k8sModelUtils.IngressHostname(serviceName, wkspCtx.Namespace, int64(cheRestApisPort))
 	ingressUrl := "http://" + ingressHost + "/api"
 
 	service := corev1.Service{
@@ -96,7 +97,7 @@ func AddCheRestApis(wkspCtx WorkspaceContext, podSpec *corev1.PodSpec) ([]runtim
 				"org.eclipse.che.machine.name":               containerName,
 			},
 			Labels: map[string]string{
-				CheOriginalNameLabel: serviceNameAndPort,
+				CheOriginalNameLabel: ingressName,
 				WorkspaceIDLabel:     wkspCtx.WorkspaceId,
 			},
 		},


### PR DESCRIPTION
### What does this PR do?
Trims ingress hostname dns parts if they are over 63 chars, to ensure that they are accessible. Commits:
1. Move all ingress metadata-provisioning code into one place, as it was previously in multiple places
2. Do the same as above but for services
3. Trim ingress hostname to max 63 chars.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15728

### Is it tested? How?
Tested on minikube 1.7.2