### PR TITLE
Add admission webhooks that provision owner annotation and deny to change it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ docker build -t quay.io/che-incubator/che-workspace-controller:7.1.0 -f ./build/
 2. `kubectl create namespace che-workspace-controller`
 3. Make sure that the right domain is set in `./deploy/controller_config.yaml` and `./deploy/registry/local/ingress.yaml`
 4. `kubectl apply -f ./deploy/registry/local`
-5. [Optional] Modify ./deploy/controller.yaml and put your docker image and pull policy there.
-6. `kubectl apply -f ./deploy`
+5. Generate certificates for Webhook server by executing: `./deploy/webhook-server-certs/deploy-webhook-server-certs.sh`
+6. [Optional] Modify ./deploy/controller.yaml and put your docker image and pull policy there.
+7. `kubectl apply -f ./deploy`
 
 ### Run controller locally
 1. `kubectl apply -f ./deploy/crds`

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Running the controller outside of the cluster depends on everything being in one
 ### Remove controller from your K8s/OS Cluster
 ```sh
 # Delete all workspaces
-kc delete workspaces.workspace.che.eclipse.org --all-namespaces --all
+kubectl delete workspaces.workspace.che.eclipse.org --all-namespaces --all
 # Remove contoller
-kc delete namespace che-workspace-controller
+kubectl delete namespace che-workspace-controller
 # Remove CRDs
-kc delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org
-kc delete customresourcedefinitions.apiextensions.k8s.io workspaces.workspace.che.eclipse.org
+kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org
+kubectl delete customresourcedefinitions.apiextensions.k8s.io workspaces.workspace.che.eclipse.org
 ```

--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ Running the controller outside of the cluster depends on everything being in one
 kc delete workspaces.workspace.che.eclipse.org --all-namespaces --all
 # Remove contoller
 kc delete namespace che-workspace-controller
-# Remove admissionwebhook configurations
-kc delete validatingwebhookconfigurations.admissionregistration.k8s.io validate-workspace-admission-hooks
-kc delete mutatingwebhookconfigurations.admissionregistration.k8s.io mutate-workspace-admission-hooks
 # Remove CRDs
 kc delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org
 kc delete customresourcedefinitions.apiextensions.k8s.io workspaces.workspace.che.eclipse.org

--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ Running the controller outside of the cluster depends on everything being in one
 1. Follow steps 1-5 for running the controller locally above
 2. `operator-sdk up local --namespace <your namespace> --enable-delve`
 3. Connect debugger to `127.0.0.1:2345` (see config in `.vscode/launch.json`)
+
+### Remove controller from your K8s/OS Cluster
+```sh
+# Delete all workspaces
+kc delete workspaces.workspace.che.eclipse.org --all-namespaces --all
+# Remove contoller
+kc delete namespace che-workspace-controller
+# Remove admissionwebhook configurations
+kc delete validatingwebhookconfigurations.admissionregistration.k8s.io validate-workspace-admission-hooks
+kc delete mutatingwebhookconfigurations.admissionregistration.k8s.io mutate-workspace-admission-hooks
+# Remove CRDs
+kc delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org
+kc delete customresourcedefinitions.apiextensions.k8s.io workspaces.workspace.che.eclipse.org
+```

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
@@ -122,7 +123,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("setting up webhooks")
+	log.Info("Setting up webhooks")
 	if err := webhook.AddToManager(mgr); err != nil {
 		log.Error(err, "unable to register webhooks to the manager")
 		os.Exit(1)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 
 	log.Info("Setting up webhooks")
-	if err := webhook.AddToManager(mgr); err != nil {
+	if err := webhook.SetUpWebhooks(mgr, ctx); err != nil {
 		log.Error(err, "unable to register webhooks to the manager")
 		os.Exit(1)
 	}

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,11 +8,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: che-workspace-controller
+      app: che-workspace-controller
   template:
     metadata:
       labels:
-        name: che-workspace-controller
+        app: che-workspace-controller
     spec:
       serviceAccountName: che-workspace-controller
       containers:
@@ -27,3 +28,29 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "che-workspace-operator"
+          ports:
+            - name: webhook-server
+              containerPort: 8443
+          volumeMounts:
+            - name: webhook-tls-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+      volumes:
+        - name: webhook-tls-certs
+          secret:
+            secretName: webhook-server-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-workspace-controller
+  name: workspace-controller
+  namespace: che-workspace-controller
+spec:
+  ports:
+    - targetPort: webhook-server
+      protocol: TCP
+      port: 443
+  selector:
+    app: che-workspace-controller

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -93,3 +93,10 @@ rules:
   - pods/exec
   verbs:
   - create
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - validatingwebhookconfigurations
+  verbs:
+    - '*'

--- a/deploy/webhook-server-certs/Dockerfile
+++ b/deploy/webhook-server-certs/Dockerfile
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+# CA key pair generation job container
+FROM alpine
+
+RUN apk add --no-cache openssl
+COPY generate-cert.sh /generate-cert.sh
+RUN mkdir /ca && /generate-cert.sh /ca
+ENTRYPOINT ["sh", "-c"]

--- a/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
+++ b/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
+# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
+# which is the cluster-internal DNS name for the service.
+#
+# NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
+
+set -e
+
+echo "Generating new TLS certificates using docker"
+PROJECT_FOLDER=$(dirname "$0")/../..
+docker build --no-cache -t generate-webhook-server-certs:latest ${PROJECT_FOLDER}/deploy/webhook-server-certs
+
+TARGET_FOLDER=$PROJECT_FOLDER/build/_output/webhook-certs
+mkdir -p $TARGET_FOLDER
+
+echo "Copying generated TLS certificates from docker container"
+docker run --name 'webhook-certs' generate-webhook-server-certs:latest exit 0
+docker cp webhook-certs:ca/. ${TARGET_FOLDER}/
+docker rm 'webhook-certs'
+
+kubectl delete secret -n che-workspace-controller webhook-server-tls --ignore-not-found=true
+kubectl -n che-workspace-controller create secret tls webhook-server-tls \
+    --cert "$TARGET_FOLDER/webhook-server-tls.crt" \
+    --key "$TARGET_FOLDER/webhook-server-tls.key"
+CA_BASE_64_CONTENT="$(openssl base64 -A <"${TARGET_FOLDER}/ca.crt")"
+kubectl patch -n che-workspace-controller secret webhook-server-tls -p="{\"data\":{\"ca.crt\": \"${CA_BASE_64_CONTENT}\"}}"
+echo "TLS certificates are stored in 'che-workspace-controller' namespace in 'webhook-server-tls' secret"
+
+rm -r ${TARGET_FOLDER}

--- a/deploy/webhook-server-certs/generate-cert.sh
+++ b/deploy/webhook-server-certs/generate-cert.sh
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
+# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
+# which is the cluster-internal DNS name for the service.
+#
+# NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
+set -e
+
+: ${1?'missing key directory'}
+
+key_dir="$1"
+
+chmod 0700 "$key_dir"
+cd "$key_dir"
+
+# Generate the CA cert and private key
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -days 1024 -subj "/CN=Admission Workspace Controller Webhook"
+# Generate the private key for the webhook server
+openssl genrsa -out webhook-server-tls.key 2048
+# Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
+openssl req -new -key webhook-server-tls.key -subj "/CN=workspace-controller.che-workspace-controller.svc" \
+    | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -days 365 -out webhook-server-tls.crt

--- a/internal/cluster/info.go
+++ b/internal/cluster/info.go
@@ -10,18 +10,13 @@
 //   Red Hat, Inc. - initial API and implementation
 //
 
-package workspace
+package cluster
 
 import (
-	"regexp"
-	"strings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
-
-var imageRegexp = regexp.MustCompile(`[^0-9a-zA-Z]`)
 
 func IsOpenShift() (bool, error) {
 	kubeCfg, err := config.GetConfig()
@@ -61,6 +56,7 @@ func findAPIResources(source []*metav1.APIResourceList, groupName string) []meta
 	return nil
 }
 
+//IsWebhookConfigurationEnabled returns true if both of mutating and validating webhook configurations are enabled
 func IsWebhookConfigurationEnabled() (bool, error) {
 	kubeCfg, err := config.GetConfig()
 	if err != nil {
@@ -92,10 +88,4 @@ func IsWebhookConfigurationEnabled() (bool, error) {
 	}
 
 	return false, nil
-}
-
-func GetContainerNameFromImage(image string) string {
-	parts := strings.Split(image, "/")
-	imageName := parts[len(parts)-1]
-	return imageRegexp.ReplaceAllString(imageName, "-")
 }

--- a/pkg/apis/addtoscheme_workspace_v1alpha1.go
+++ b/pkg/apis/addtoscheme_workspace_v1alpha1.go
@@ -13,8 +13,8 @@
 package apis
 
 import (
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	apis "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
-	utils "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
 	routeV1 "github.com/openshift/api/route/v1"
 	templateV1 "github.com/openshift/api/template/v1"
 )
@@ -24,7 +24,7 @@ func init() {
 	AddToSchemes = append(AddToSchemes,
 		apis.SchemeBuilder.AddToScheme,
 	)
-	if isOS, err := utils.IsOpenShift(); isOS && err == nil {
+	if isOS, err := cluster.IsOpenShift(); isOS && err == nil {
 		AddToSchemes = append(AddToSchemes,
 			routeV1.AddToScheme,
 			templateV1.AddToScheme,

--- a/pkg/controller/modelutils/k8s/container.go
+++ b/pkg/controller/modelutils/k8s/container.go
@@ -9,11 +9,12 @@
 // Contributors:
 //   Red Hat, Inc. - initial API and implementation
 //
-
 package utils
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"regexp"
+	"strings"
 )
 
 func BuildContainerPorts(exposedPorts []int, protocol corev1.Protocol) []corev1.ContainerPort {
@@ -28,4 +29,12 @@ func BuildContainerPorts(exposedPorts []int, protocol corev1.Protocol) []corev1.
 		return nil
 	}
 	return containerPorts
+}
+
+var imageRegexp = regexp.MustCompile(`[^0-9a-zA-Z]`)
+
+func GetContainerNameFromImage(image string) string {
+	parts := strings.Split(image, "/")
+	imageName := parts[len(parts)-1]
+	return imageRegexp.ReplaceAllString(imageName, "-")
 }

--- a/pkg/controller/modelutils/k8s/ingress.go
+++ b/pkg/controller/modelutils/k8s/ingress.go
@@ -1,3 +1,14 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
 package utils
 
 import (

--- a/pkg/controller/modelutils/k8s/service.go
+++ b/pkg/controller/modelutils/k8s/service.go
@@ -9,7 +9,6 @@
 // Contributors:
 //   Red Hat, Inc. - initial API and implementation
 //
-
 package utils
 
 import (

--- a/pkg/controller/ownerref/ownerref.go
+++ b/pkg/controller/ownerref/ownerref.go
@@ -1,0 +1,74 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package ownerref
+
+import (
+	"context"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var Log = logf.Log.WithName("ownerref")
+
+//FindControllerOwner returns OwnerReferent that owns controller process
+//it starts searching from the current pod and then resolves owners recursively
+//until object without owner is not found
+func FindControllerOwner(ctx context.Context, client crclient.Client) (*metav1.OwnerReference, error) {
+	ns, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current Pod the operator is running in
+	pod, err := k8sutil.GetPod(ctx, client, ns)
+	if err != nil {
+		return nil, err
+	}
+	podOwnerRefs := metav1.NewControllerRef(pod, pod.GroupVersionKind())
+	// Get Owner that the Pod belongs to
+	ownerRef := metav1.GetControllerOf(pod)
+	finalOwnerRef, err := findFinalOwnerRef(ctx, client, ns, ownerRef)
+	if err != nil {
+		return nil, err
+	}
+	if finalOwnerRef != nil {
+		return finalOwnerRef, nil
+	}
+
+	// Default to returning Pod as the Owner
+	return podOwnerRefs, nil
+}
+
+// findFinalOwnerRef tries to locate the final controller/owner based on the owner reference provided.
+func findFinalOwnerRef(ctx context.Context, client crclient.Client, ns string, ownerRef *metav1.OwnerReference) (*metav1.OwnerReference, error) {
+	if ownerRef == nil {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ownerRef.APIVersion)
+	obj.SetKind(ownerRef.Kind)
+	err := client.Get(ctx, types.NamespacedName{Namespace: ns, Name: ownerRef.Name}, obj)
+	if err != nil {
+		return nil, err
+	}
+	newOwnerRef := metav1.GetControllerOf(obj)
+	if newOwnerRef != nil {
+		return findFinalOwnerRef(ctx, client, ns, newOwnerRef)
+	}
+
+	Log.V(1).Info("Pods owner found", "Kind", ownerRef.Kind, "Name", ownerRef.Name, "Namespace", ns)
+	return ownerRef, nil
+}

--- a/pkg/controller/workspace/component/converter.go
+++ b/pkg/controller/workspace/component/converter.go
@@ -103,7 +103,8 @@ func buildMainDeployment(wkspCtx WorkspaceContext, workspace *workspaceApi.Works
 
 	var user *int64
 	if !ControllerCfg.IsOpenShift() {
-		*user = 1234
+		uID := int64(1234)
+		user = &uID
 	}
 
 	deploy := appsv1.Deployment{

--- a/pkg/controller/workspace/component/plugins.go
+++ b/pkg/controller/workspace/component/plugins.go
@@ -14,10 +14,10 @@ package component
 
 import (
 	"encoding/json"
+	utils "github.com/che-incubator/che-workspace-operator/pkg/controller/modelutils/k8s"
 
 	workspaceApi "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
-	workspace "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
 	metadataBroker "github.com/eclipse/che-plugin-broker/brokers/metadata"
 	brokerModel "github.com/eclipse/che-plugin-broker/model"
 	corev1 "k8s.io/api/core/v1"
@@ -73,7 +73,7 @@ func getArtifactsBrokerObjects(wkspCtx model.WorkspaceContext, components []work
 	)
 	configMapName := fmt.Sprintf("%s.broker-config-map", wkspCtx.WorkspaceId)
 	brokerImage := config.ControllerCfg.GetPluginArtifactsBrokerImage()
-	brokerContainerName := workspace.GetContainerNameFromImage(brokerImage)
+	brokerContainerName := utils.GetContainerNameFromImage(brokerImage)
 
 	// Define plugin broker configmap
 	var fqns []brokerModel.PluginFQN

--- a/pkg/controller/workspace/config/config.go
+++ b/pkg/controller/workspace/config/config.go
@@ -15,6 +15,7 @@ package config
 import (
 	"context"
 	"errors"
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/registry"
 	"os"
 	"strings"
@@ -34,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/log"
-	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
 
 	"fmt"
 )
@@ -217,7 +217,7 @@ func buildDefaultConfigMap(cm *corev1.ConfigMap) {
 }
 
 func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMap *corev1.ConfigMap) error {
-	isOS, err := IsOpenShift()
+	isOS, err := cluster.IsOpenShift()
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/workspace/model/globals.go
+++ b/pkg/controller/workspace/model/globals.go
@@ -47,4 +47,6 @@ const (
 
 	//CheOriginalNameLabel is label key to original name
 	CheOriginalNameLabel = "che.original_name"
+
+	WorkspaceCreatorAnnotation = "org.eclipse.che.workspace/creator"
 )

--- a/pkg/controller/workspace/utils/utilities.go
+++ b/pkg/controller/workspace/utils/utilities.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
@@ -35,12 +36,61 @@ func IsOpenShift() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	apiGroups := apiList.Groups
-	for i := 0; i < len(apiGroups); i++ {
-		if apiGroups[i].Name == "route.openshift.io" {
-			return true, nil
+	if findAPIGroup(apiList.Groups, "route.openshift.io") == nil {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
+func findAPIGroup(source []metav1.APIGroup, apiName string) *metav1.APIGroup {
+	for i := 0; i < len(source); i++ {
+		if source[i].Name == apiName {
+			return &source[i]
 		}
 	}
+	return nil
+}
+
+func findAPIResources(source []*metav1.APIResourceList, groupName string) []metav1.APIResource {
+	for i := 0; i < len(source); i++ {
+		if source[i].GroupVersion == groupName {
+			return source[i].APIResources
+		}
+	}
+	return nil
+}
+
+func IsWebhookConfigurationEnabled() (bool, error) {
+	kubeCfg, err := config.GetConfig()
+	if err != nil {
+		return false, err
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(kubeCfg)
+	if err != nil {
+		return false, err
+	}
+	_, apiResources, err := discoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return false, err
+	}
+
+	if admissionRegistrationResources := findAPIResources(apiResources, "admissionregistration.k8s.io/v1beta1"); admissionRegistrationResources != nil {
+		isMutatingHookAvailable := false
+		isValidatingMutatingHookAvailable := false
+		for i := range admissionRegistrationResources {
+			if admissionRegistrationResources[i].Name == "mutatingwebhookconfigurations" {
+				isMutatingHookAvailable = true
+			}
+
+			if admissionRegistrationResources[i].Name == "validatingwebhookconfigurations" {
+				isValidatingMutatingHookAvailable = true
+			}
+		}
+
+		return isMutatingHookAvailable && isValidatingMutatingHookAvailable, nil
+	}
+
 	return false, nil
 }
 

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -15,6 +15,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	origLog "log"
 	"os"
 	"reflect"
@@ -51,7 +52,6 @@ import (
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/log"
 	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
-	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
 )
 
 // Add creates a new Workspace Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -136,7 +136,7 @@ func add(mgr manager.Manager, r *ReconcileWorkspace) error {
 
 	origLog.SetOutput(r)
 
-	isOS, err := IsOpenShift()
+	isOS, err := cluster.IsOpenShift()
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/add_creator_webhooks.go
+++ b/pkg/webhook/add_creator_webhooks.go
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package webhook
+
+import "github.com/che-incubator/che-workspace-operator/pkg/webhook/creator"
+
+func init() {
+	AddToManagerFuncs = append(AddToManagerFuncs, creator.Add)
+}

--- a/pkg/webhook/add_creator_webhooks.go
+++ b/pkg/webhook/add_creator_webhooks.go
@@ -13,5 +13,5 @@ package webhook
 import "github.com/che-incubator/che-workspace-operator/pkg/webhook/creator"
 
 func init() {
-	AddToManagerFuncs = append(AddToManagerFuncs, creator.Add)
+	configureWebhookTasks = append(configureWebhookTasks, creator.SetUp)
 }

--- a/pkg/webhook/creator/creator.go
+++ b/pkg/webhook/creator/creator.go
@@ -12,49 +12,75 @@
 package creator
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
+	"context"
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/ownerref"
+	"k8s.io/api/admissionregistration/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var log = logf.Log.WithName("webhook.creator")
 
-func Add(mgr manager.Manager) error {
-	kubeCfg, err := config.GetConfig()
-	if err != nil {
-		return err
-	}
-
-	client, err := kubernetes.NewForConfig(kubeCfg)
-	if err != nil {
-		return err
-	}
-
+//SetUp set up mutate webhook that manager creator annotations for workspaces
+func SetUp(webhookServer *webhook.Server, ctx context.Context) error {
 	log.Info("Configuring creator mutating webhook")
-	mutateWebhook, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(mutateWebhookCfgName, metav1.GetOptions{})
+	client, err := createClient()
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			return err
-		}
+		return err
+	}
 
-		_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(buildMutateWebhookCfg())
-		if err != nil {
+	mutateWebhookCfg := buildMutateWebhookCfg()
+
+	ownRef, err := ownerref.FindControllerOwner(ctx, client)
+	if err != nil {
+		return err
+	}
+	//TODO For some reasons it's still possible to update reference by user
+	//TODO Investigate if we can block it. The same issue is valid for Deployment owner
+	mutateWebhookCfg.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
+
+	if err := client.Create(ctx, mutateWebhookCfg); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
 			return err
 		}
-		log.Info("Created creator mutating webhook configuration")
-	} else {
-		mutateWebhookCfg := buildMutateWebhookCfg()
-		mutateWebhookCfg.ObjectMeta.ResourceVersion = mutateWebhook.ObjectMeta.ResourceVersion
-		_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(mutateWebhookCfg)
+		// Webhook Configuration already exists, we want to update it
+		// as we do not know if any fields might have changed.
+		existingCfg := &v1beta1.MutatingWebhookConfiguration{}
+		err := client.Get(ctx, types.NamespacedName{
+			Name:      mutateWebhookCfg.Name,
+			Namespace: mutateWebhookCfg.Namespace,
+		}, existingCfg)
+
+		mutateWebhookCfg.ResourceVersion = existingCfg.ResourceVersion
+		err = client.Update(ctx, mutateWebhookCfg)
 		if err != nil {
 			return err
 		}
 		log.Info("Updated creator mutating webhook configuration")
+	} else {
+		log.Info("Created creator mutating webhook configuration")
 	}
-	mgr.GetWebhookServer().Register(mutateWebhookPath, &webhook.Admission{Handler: &WorkspaceAnnotator{}})
+
+	webhookServer.Register(mutateWebhookPath, &webhook.Admission{Handler: &WorkspaceAnnotator{}})
 	return nil
+}
+
+//TODO It's copied/pasted from embedded_registry. Consider move it to util class
+func createClient() (crclient.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := crclient.New(cfg, crclient.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
 }

--- a/pkg/webhook/creator/creator.go
+++ b/pkg/webhook/creator/creator.go
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package creator
+
+import (
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var log = logf.Log.WithName("webhook.creator")
+
+func Add(mgr manager.Manager) error {
+	kubeCfg, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(kubeCfg)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Configuring creator mutating webhook")
+	mutateWebhook, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(mutateWebhookCfgName, metav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+
+		_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(buildMutateWebhookCfg())
+		if err != nil {
+			return err
+		}
+		log.Info("Created creator mutating webhook configuration")
+	} else {
+		mutateWebhookCfg := buildMutateWebhookCfg()
+		mutateWebhookCfg.ObjectMeta.ResourceVersion = mutateWebhook.ObjectMeta.ResourceVersion
+		_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Update(mutateWebhookCfg)
+		if err != nil {
+			return err
+		}
+		log.Info("Updated creator mutating webhook configuration")
+	}
+	mgr.GetWebhookServer().Register(mutateWebhookPath, &webhook.Admission{Handler: &WorkspaceAnnotator{}})
+	return nil
+}

--- a/pkg/webhook/creator/mutatingwebhook.go
+++ b/pkg/webhook/creator/mutatingwebhook.go
@@ -1,0 +1,124 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package creator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/model"
+	"k8s.io/api/admission/v1beta1"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WorkspaceAnnotator annotates Workspaces
+type WorkspaceAnnotator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// WorkspaceAnnotator adds an creator annotation to every incoming workspaces.
+func (a *WorkspaceAnnotator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	switch req.Operation {
+	case v1beta1.Create:
+		return a.handleCreate(ctx, req)
+	case v1beta1.Update:
+		return a.handleUpdate(ctx, req)
+	default:
+		return admission.Denied(fmt.Sprintf("This admission is not supposed to handle %s operation. Please revise configuration", req.Operation))
+	}
+}
+
+func (a *WorkspaceAnnotator) handleCreate(_ context.Context, req admission.Request) admission.Response {
+	wksp := &v1alpha1.Workspace{}
+
+	err := a.decoder.Decode(req, wksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	log.Info("Provision creator annotation", "workspaceId", wksp.Status.WorkspaceId, "creator", req.UserInfo.UID)
+
+	if wksp.Annotations == nil {
+		wksp.Annotations = map[string]string{}
+	}
+	wksp.Annotations[model.WorkspaceCreatorAnnotation] = req.UserInfo.UID
+
+	marshaledWksp, err := json.Marshal(wksp)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledWksp)
+}
+
+func (a *WorkspaceAnnotator) handleUpdate(ctx context.Context, req admission.Request) admission.Response {
+	newWksp := &v1alpha1.Workspace{}
+	oldWksp := &v1alpha1.Workspace{}
+
+	err := a.decoder.Decode(req, newWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	err = a.decoder.DecodeRaw(req.OldObject, oldWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	oldCreator, found := oldWksp.Annotations[model.WorkspaceCreatorAnnotation]
+	if !found {
+		log.Info(fmt.Sprintf("WARN: Worskpace %s does not have creator annotation. It happens only for old "+
+			"workspaces or when mutating webhook is not configured properly", newWksp.ObjectMeta.UID))
+		return returnPatchedWithUser(req.Object.Raw, newWksp, req.UserInfo.UID)
+	}
+
+	newCreator, found := newWksp.Annotations[model.WorkspaceCreatorAnnotation]
+	if !found {
+		return returnPatchedWithUser(req.Object.Raw, newWksp, oldCreator)
+	}
+
+	if newCreator != oldCreator {
+		return admission.Denied(fmt.Sprintf("annotation %s is immutable and must have value: %q", model.WorkspaceCreatorAnnotation, oldCreator))
+	}
+
+	return admission.Allowed("new workspace has the same creator as old one")
+}
+
+func returnPatchedWithUser(original []byte, patchedWksp *v1alpha1.Workspace, creator string) admission.Response {
+	patchedWksp.Annotations[model.WorkspaceCreatorAnnotation] = creator
+
+	marshaledWksp, err := json.Marshal(patchedWksp)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(original, marshaledWksp)
+}
+
+// WorkspaceAnnotator implements inject.Client.
+// A client will be automatically injected.
+
+// InjectClient injects the client.
+func (a *WorkspaceAnnotator) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
+}
+
+// WorkspaceAnnotator implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+
+// InjectDecoder injects the decoder.
+func (a *WorkspaceAnnotator) InjectDecoder(d *admission.Decoder) error {
+	a.decoder = d
+	return nil
+}

--- a/pkg/webhook/creator/mutatingwebhookcfg.go
+++ b/pkg/webhook/creator/mutatingwebhookcfg.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package creator
+
+import (
+	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
+	"k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	mutateWebhookCfgName       = "mutate-workspace-admission-hooks"
+	mutateWebhookPath          = "/mutate-workspaces"
+	mutateWebhookFailurePolicy = v1beta1.Fail
+)
+
+func buildMutateWebhookCfg() *v1beta1.MutatingWebhookConfiguration {
+	mutateWebhookFailurePolicy := mutateWebhookFailurePolicy
+	mutateWebhookPath := mutateWebhookPath
+	return &v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mutateWebhookCfgName,
+		},
+		Webhooks: []v1beta1.MutatingWebhook{
+			{
+				Name:          "mutate-workspaces.che-workspace-controller.svc",
+				FailurePolicy: &mutateWebhookFailurePolicy,
+				ClientConfig: v1beta1.WebhookClientConfig{
+					Service: &v1beta1.ServiceReference{
+						Name:      "workspace-controller",
+						Namespace: "che-workspace-controller",
+						Path:      &mutateWebhookPath,
+					},
+					CABundle: server.CABundle,
+				},
+				Rules: []v1beta1.RuleWithOperations{
+					{
+						Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+						Rule: v1beta1.Rule{
+							APIGroups:   []string{"workspace.che.eclipse.org"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"workspaces"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package server
+
+import (
+	utils "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
+	"io/ioutil"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+const (
+	webhookServerHost    = "0.0.0.0"
+	webhookServerPort    = 8443
+	webhookServerCertDir = "/tmp/k8s-webhook-server/serving-certs"
+)
+
+var log = logf.Log.WithName("webhook.server")
+
+var CABundle []byte
+
+func ConfigureWebhookServer(mgr manager.Manager) (bool, error) {
+	enabled, err := utils.IsWebhookConfigurationEnabled()
+
+	if err != nil {
+		log.Info("ERROR: Could not evaluate if admission webhook configurations are available", "error", err)
+		return false, err
+	}
+
+	if !enabled {
+		log.Info("WARN: AdmissionWebhooks are not configured at your cluster." +
+			"    To make your workspaces more secure, please configuring them." +
+			"    Skipping setting up Webhook Server")
+		return false, nil
+	}
+
+	CABundle, err = ioutil.ReadFile(webhookServerCertDir + "/ca.crt")
+	if os.IsNotExist(err) {
+		log.Info("CA certificate is not found. Webhook server is not set up")
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	log.Info("Setting up webhook server")
+	mgr.GetWebhookServer().Port = webhookServerPort
+	mgr.GetWebhookServer().Host = webhookServerHost
+	mgr.GetWebhookServer().CertDir = webhookServerCertDir
+
+	return true, nil
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -11,7 +11,7 @@
 package server
 
 import (
-	utils "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/utils"
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	"io/ioutil"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -29,7 +29,7 @@ var log = logf.Log.WithName("webhook.server")
 var CABundle []byte
 
 func ConfigureWebhookServer(mgr manager.Manager) (bool, error) {
-	enabled, err := utils.IsWebhookConfigurationEnabled()
+	enabled, err := cluster.IsWebhookConfigurationEnabled()
 
 	if err != nil {
 		log.Info("ERROR: Could not evaluate if admission webhook configurations are available", "error", err)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -9,12 +9,15 @@
 // Contributors:
 //   Red Hat, Inc. - initial API and implementation
 //
-
 package webhook
 
 import (
+	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.Log.WithName("webhook")
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
@@ -23,9 +26,18 @@ var AddToManagerFuncs []func(manager.Manager) error
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-func AddToManager(m manager.Manager) error {
+func AddToManager(mgr manager.Manager) error {
+	success, err := server.ConfigureWebhookServer(mgr)
+	if !success {
+		if err != nil {
+			return err
+		} else {
+			log.Info("Webhook server is not set up. Skipping webhook cfg registration")
+		}
+	}
+
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(mgr); err != nil {
 			return err
 		}
 	}

--- a/samples/cloud-shell.yaml
+++ b/samples/cloud-shell.yaml
@@ -21,7 +21,7 @@ spec:
         memoryLimit: 256Mi
         alias: dev
         image: 'quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509'
-        command: ["tail", "-f", "/dev/null"]
+        args: ["tail", "-f", "/dev/null"]
         env:
           - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
             name: PS1


### PR DESCRIPTION
### What does this PR do?
It's an initial implementation for admission webhooks that provision owner annotation and deny to change it:
- when workspace is created, user info is provisioned, if a user specifies it - it's overridden
- when workspace is updated:
  - the creator is missing - provision from previous workspace state
       - if the previous state miss it as well - provision the current user as creator
  - the creator is unchanged - do nothing
  - the creator is changed - deny operation with a message, like: `annotation org.eclipse.che.workspace/creator is immutable and must have value: "7c922737-54b6-11ea-bd4d-080027a7b4ae`

What should be considered to be improved:
- It's needed to investigate how we can get certificates for webhook server with OLM, maybe controller should generate certs by itself, for example with https://github.com/operator-framework/operator-sdk/blob/master/pkg/tls/tls.go#L123;
- Revise if it's a good idea to create admission configuration from code, like if we rename configuration name - then in the controller code we should clean up old one, maybe there is a better approach;
- Now webhooks are optional and they will be not configured if there are some issues with K8s cluster or controller configuration. It would be safer to make them required by default and fail if there are some issues but add an ability to disable them with ConfigMap.
- there is no user info on minikube, it's needed to revise what to do? Not Webhooks Configuration just provisions empty value and deny to change it.

Next steps:
1. Make Workspace Controller propagate creator annotations to Workspace Deployment
2. Add ValidaitngWebhook that deny changing creator annotation for workspace-related Deployment/Pod
3. Add ValidatingWebhook that denies creating exec into Pods for everyone except the creator.

As an alternative, we could go with only third webhook that which would find workspace related to current pod with reference Pod->Deployment->Workspace CR, but it means that each exec requires a few additional requests on Webhook Server side...
So, these ways should be compared.

**Minor changes:**
- Added instructions how to remove workspace controller from cluster
- Fix NPE during provisioning userID on k8s cluster
![Screenshot_20200226_090814](https://user-images.githubusercontent.com/5887312/75338901-2fe48480-5898-11ea-92e3-1d176eb9f3b0.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16056

### Is it tested? How?
It's tested on minishift with the following scenario:
1. `minishift addon apply admissions-webhook`. Without it controller will report them webhooks are configured but they won't work. See https://github.com/minishift/minishift/issues/3422
2. Deploy Workspace Controller as usual.
3. Create test workspace and make sure that creator annotation is provisioned, like `kc get workspace cloud-shell -o=yaml | grep creator`.
4. Try to modify creator annotation, like `kc patch workspace cloud-shell --type='merge' -p '{"metadata":{"annotations":{"org.eclipse.che.workspace/creator":"newuser"}}}'`
I'm going to retest it on minikube as well. But it does not prevent from reviewing.

:warning: If you face the following issue:
> Error from server (InternalError): error when creating "./samples/cloud-shell.yaml": Internal error occurred: failed calling admission webhook "mutate-workspaces.che-workspace-controller.svc": Post https://workspace-controller.che-workspace-controller.svc:443/mutate-workspaces?timeout=30s: x509: certificate has expired or is not yet valid

Then probably your minishift has outdated time, to make it up to date, execute:
```
minishift ssh "sudo yum install chrony -y"
  minishift ssh "sudo sed -i 's/makestep 1.0 3/makestep 1.0 -1/g' /etc/chrony.conf"
  minishift ssh "sudo sed -i 's/\#allow/allow/g' /etc/chrony.conf"
  minishift ssh "sudo systemctl enable chronyd"
  minishift ssh "sudo systemctl start chronyd"
  minishift ssh "sudo systemctl status chronyd"
```

Dockerimage to test: `sleshchenko/che-workspace-controller:webhook`

It's also tested on minikube, but user id, in that case, is just an empty string.