### PR TITLE
Propagate access token by OpenShift OAuth proxy

### DIFF
--- a/deploy/exec-cluster-role.yaml.yaml
+++ b/deploy/exec-cluster-role.yaml.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pods-exec
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
+++ b/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
@@ -184,7 +184,11 @@ func (solver *OpenshiftOAuthSolver) CreateRoutes(cr CurrentReconcile) []runtime.
 								"--upstream=http://" + serviceDesc.ServiceName + ":" + targetPortString,
 								"--tls-cert=/etc/tls/private/tls.crt",
 								"--tls-key=/etc/tls/private/tls.key",
-								"--cookie-secret=SECRET",
+								"--cookie-secret=0123456789abcdefabcd",
+								"--cookie-secure=false",
+								"--pass-user-bearer-token=false",
+								"--pass-access-token=true",
+								"--scope=user:info user:check-access role:pods-exec:" + cr.Instance.Namespace,
 							},
 						})
 

--- a/samples/cloud-shell-oauth.yaml
+++ b/samples/cloud-shell-oauth.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cloud-shell
 spec:
   started: true
+  routingClass: openshift-oauth
   devfile:
     apiVersion: 0.0.1
     metadata:


### PR DESCRIPTION
### What does this PR do?
I've extracted it from my draft to make others able to try USE_BEARER_TOKEN feature implemented in https://github.com/eclipse/che-machine-exec/pull/85 before I merge webhooks which restrict exec access for owner only.

### What issues does this PR fix or reference?
It's needed to try https://github.com/eclipse/che-machine-exec/pull/85

### Is it tested? How?
I've tested it on crc.
1. oc apply -f ./samples/cloud-shell-oauth.yaml
2. oc edit deployment WORKPSACE_DEPLOYMENT and provision the following env var:
```
- name: LOG_LEVEL
   value: debug
```
3. Wait until pod is affected and opened terminal, make sure that SA token is used
![Screenshot_20200320_172613](https://user-images.githubusercontent.com/5887312/77178906-6b0d5880-6ad0-11ea-8662-cf2b9afcbee4.png)
4. oc edit deployment WORKPSACE_DEPLOYMENT and provision the following env var:
```
- name: USE_BEARER_TOKEN
   value: "true"
```
5. Wait until pod is affected and opened terminal, make sure that bearer token is used
![Screenshot_20200320_172802](https://user-images.githubusercontent.com/5887312/77178984-8aa48100-6ad0-11ea-83e3-c4eeda9acfda.png)
