### PR TITLE
Fix workspaces with OpenShift OAuth and webhooks enabled

### DIFF
--- a/pkg/controller/workspace/component/plugins_utils.go
+++ b/pkg/controller/workspace/component/plugins_utils.go
@@ -155,6 +155,14 @@ func convertContainers(pluginContainers []brokerModel.Container, wkspCtx model.W
 		if err != nil {
 			return nil, err
 		}
+
+		if config.ControllerCfg.GetWebhooksEnabled() == "true" {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name: "USE_BEARER_TOKEN",
+				Value: "true",
+			})
+		}
+
 		containers = append(containers, container)
 	}
 	return containers, nil

--- a/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
+++ b/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
@@ -18,7 +18,7 @@ import (
 	"strconv"
 
 	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
-	. "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
+	cfg "github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/config"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	routeV1 "github.com/openshift/api/route/v1"
@@ -167,7 +167,7 @@ func (solver *OpenshiftOAuthSolver) CreateRoutes(cr CurrentReconcile) []runtime.
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
-							ImagePullPolicy: corev1.PullPolicy(ControllerCfg.GetSidecarPullPolicy()),
+							ImagePullPolicy: corev1.PullPolicy(cfg.ControllerCfg.GetSidecarPullPolicy()),
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      "proxy-tls" + proxyCountString,

--- a/pkg/webhook/workspace/handler/exec.go
+++ b/pkg/webhook/workspace/handler/exec.go
@@ -44,7 +44,7 @@ func (h *WebhookHandler) ValidateExecOnConnect(ctx context.Context, req admissio
 	}
 
 	if creator != req.UserInfo.UID {
-		return admission.Denied("The only workspace workspace has exec access")
+		return admission.Denied("The only workspace creator has exec access")
 	}
 
 	return admission.Allowed("The current user and workspace are matched")


### PR DESCRIPTION
### What does this PR do?
Not every plugin needs bearer token, so it's not the best solution but I decided to create such a quick fix since it will be replaced with new controller architecture.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16252

### Is it tested? How?
1. Create cloud-shell-oauth workspace as developer
2. Try to open it with kube:admin
![Screenshot_20200327_143249](https://user-images.githubusercontent.com/5887312/77756851-b677b780-7038-11ea-83d7-8787baa77f6a.png)
3. Try to open it with developer
![Screenshot_20200327_143330](https://user-images.githubusercontent.com/5887312/77756587-276a9f80-7038-11ea-960f-1defbc203ded.png)

I've tested the use case without webhooks enabled as well.