### PR TITLE
Remove webhooks configurations if they are disabled via ConfigMap

### DIFF
--- a/pkg/webhook/add_creator_webhooks.go
+++ b/pkg/webhook/add_creator_webhooks.go
@@ -13,5 +13,5 @@ package webhook
 import "github.com/che-incubator/che-workspace-operator/pkg/webhook/workspace"
 
 func init() {
-	configureWebhookTasks = append(configureWebhookTasks, workspace.SetUp)
+	configureWebhookTasks = append(configureWebhookTasks, workspace.Configure)
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -16,31 +16,25 @@ import (
 	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var log = logf.Log.WithName("webhook")
 
 // configureWebhookTasks is a list of functions to add set webhook up and add them to the Manager
-var configureWebhookTasks []func(*webhook.Server, context.Context) error
+var configureWebhookTasks []func(context.Context) error
 
 // SetUpWebhooks sets up Webhook server and registers webhooks configurations
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 func SetUpWebhooks(mgr manager.Manager, ctx context.Context) error {
-	success, err := server.ConfigureWebhookServer(mgr)
-	if !success {
-		if err != nil {
-			return err
-		} else {
-			log.Info("Webhook server is not set up. Skipping webhook cfg registration")
-			return nil
-		}
+	err := server.ConfigureWebhookServer(mgr)
+	if err != nil {
+		return err
 	}
 
 	for _, f := range configureWebhookTasks {
-		if err := f(mgr.GetWebhookServer(), ctx); err != nil {
+		if err := f(ctx); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### What does this PR do?
Remove webhooks configurations if they are disabled via ConfigMap

### What issues does this PR fix or reference?
Partially fixes -> https://github.com/eclipse/che/issues/16442

### Is it tested? How?
Yeap!
Webhooks are enabled
![Screenshot_20200330_114901](https://user-images.githubusercontent.com/5887312/77895825-03999a80-7280-11ea-8bee-9235d34d1092.png)
Webhooks are still enabled
![Screenshot_20200330_114943](https://user-images.githubusercontent.com/5887312/77895849-0e542f80-7280-11ea-8a86-20d3d6ffef3a.png)
Webhooks are disabled
![Screenshot_20200330_120124](https://user-images.githubusercontent.com/5887312/77895882-17dd9780-7280-11ea-86bf-0d6315535cf7.png)

