### PR TITLE
Cut route name to contains only 10 letter from service + port

### DIFF
--- a/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
+++ b/pkg/controller/workspacerouting/openshift_oauth_proxy_solver.go
@@ -64,7 +64,7 @@ func (solver *OpenshiftOAuthSolver) CreateDiscoverableServices(cr CurrentReconci
 
 func routeName(serviceDesc workspacev1alpha1.ServiceDescription, endpoint workspacev1alpha1.Endpoint) string {
 	portString := strconv.FormatInt(endpoint.Port, 10)
-	return serviceDesc.ServiceName + "-" + portString
+	return serviceDesc.ServiceName[0:10] + "-" + portString
 }
 
 func routeHost(serviceDesc workspacev1alpha1.ServiceDescription, endpoint workspacev1alpha1.Endpoint, routing *workspacev1alpha1.WorkspaceRouting) string {


### PR DESCRIPTION
### What does this PR do?
Cut route name to contains only 10 letters from service + port

### What issues does this PR fix or reference?
It workarounds https://github.com/eclipse/che/issues/16496 and the proper solution will be provided by refactored reconcile loop

### Is it tested? How?
![Screenshot_20200331_174313](https://user-images.githubusercontent.com/5887312/78039883-57d37600-7377-11ea-9b58-584ffdf53c54.png)

