### PR TITLE
Fix makefile issues due to rebasing over PR #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The repository contains a Makefile; building and deploying can be configured via
 | `CLUSTER_IP` | For Kubernetes only, the ip address of the cluster (`minikube ip`) | `192.168.99.100` |
 | `PULL_POLICY` | Image pull policy for controller | `Always` |
 | `WEBHOOK_ENABLED` | Whether webhooks should be enabled in the deployment | `false` |
+| `DEFAULT_ROUTING` | Default routingClass to apply to workspaces that don't specify one | `basic` |
 
 The makefile supports the following rules:
 


### PR DESCRIPTION
### What does this PR do?
Fix the makefile after rebasing over #35, which moved some yamls around in the deploy folder -- I failed to check for this before merging.

It also adds support for setting default routing class when deploying.

### Is it tested? How?
Tested on crc with options
```
export IMG=amisevsk/che-workspace-controller:dev
export OPERATOR_NAME=che-workspace-operator
export WEBHOOK_ENABLED=true
export DEFAULT_ROUTING=openshift-oauth
```