### PR TITLE
Add an ability to configure already deployed controller with make

### DIFF
--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         app: che-workspace-controller
+      annotations:
+        kubectl.kubernetes.io/restartedAt: ""
     spec:
       serviceAccountName: che-workspace-controller
       containers:

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: che-workspace-controller
+      annotations:
+        kubectl.kubernetes.io/restartedAt: ""
     spec:
       serviceAccountName: che-workspace-controller
       containers:


### PR DESCRIPTION
### What does this PR do?
Adds a command to update controller configuration according to the set env vars and actual configuration files state (for example while testing some branch).

Trigger reconfigure during rollout to make sure that the right image is used with the right configuration files.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Used it but not sure about corner cases.