### PR TITLE
Cut ingress hostname

### DIFF
--- a/pkg/controller/modelutils/k8s/ingress.go
+++ b/pkg/controller/modelutils/k8s/ingress.go
@@ -32,5 +32,5 @@ func IngressHostname(serviceName, namespace string, port int64) string {
 // IngressName generates a names for ingresses
 func IngressName(serviceName string, port int64) string {
 	portString := strconv.FormatInt(port, 10)
-	return serviceName + "-" + portString
+	return serviceName[0:10] + "-" + portString
 }


### PR DESCRIPTION
### What does this PR do?
I've created this PR which cuts ingress hostname since Abhi is blocked:
- basic routing class does not work because of ingress hostname length;
- openshift oauth routing does not work because of openshift oauth issues on devclusters;

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
yeah, tested on devcluster with basic routing class.
