### PR TITLE
Create OAuthClient for OpenShift OAuth Proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ _update_controller_configmap:
 
 _apply_controller_cfg:
 	$(TOOL) apply -f ./deploy
+	$(TOOL) apply -f ./deploy/role.yaml
 ifeq ($(TOOL),oc)
 	$(TOOL) apply -f ./deploy/os/
 else

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,13 @@ _do_uninstall:
 # leave workspaces in a hanging state if we add finalizers.
 ifneq ($(shell command -v kubectl 2> /dev/null),)
 	kubectl delete workspaces.workspace.che.eclipse.org --all-namespaces --all
+# Have to wait for routings to be deleted in case there are finalizers
+	kubectl delete workspaceroutings.workspace.che.eclipse.org --all-namespaces --all --wait
 else
-	$(info WARN: kubectl is not installed: unable to delete all workspaces)
+ifneq ($(TOOL) get workspaces.workspace.che.eclipse.org --all-namespaces,"No resources found.")
+	$(info To automatically remove all workspaces when uninstalling, ensure kubectl is installed)
+	$(error Cannot uninstall operator, workspaces still running. Delete all workspaces and workspaceroutings before proceeding)
+endif
 endif
 	$(TOOL) delete namespace $(NAMESPACE)
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org

--- a/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
@@ -2198,7 +2198,8 @@ spec:
                         additionalProperties:
                           type: string
                         description: Annotations for the workspace service account,
-                          required for e.g. OpenShift oauth
+                          it might be used for e.g. OpenShift oauth with SA as auth
+                          client
                         type: object
                       volumes:
                         description: Volumes to add to workspace deployment

--- a/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
@@ -1917,8 +1917,8 @@ spec:
                 serviceAccountAnnotations:
                   additionalProperties:
                     type: string
-                  description: Annotations for the workspace service account, required
-                    for e.g. OpenShift oauth
+                  description: Annotations for the workspace service account, it might
+                    be used for e.g. OpenShift oauth with SA as auth client
                   type: object
                 volumes:
                   description: Volumes to add to workspace deployment

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -100,3 +100,15 @@ rules:
     - validatingwebhookconfigurations
   verbs:
     - '*'
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - create
+  - get
+  - delete
+  - list
+  - patch
+  - update
+  - watch

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -112,3 +112,4 @@ rules:
   - patch
   - update
   - watch
+  - deletecollection

--- a/pkg/apis/addtoscheme_workspace_v1alpha1.go
+++ b/pkg/apis/addtoscheme_workspace_v1alpha1.go
@@ -15,6 +15,7 @@ package apis
 import (
 	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routeV1 "github.com/openshift/api/route/v1"
 	templateV1 "github.com/openshift/api/template/v1"
 )
@@ -24,8 +25,9 @@ func init() {
 	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
 	if isOS, err := cluster.IsOpenShift(); isOS && err == nil {
 		AddToSchemes = append(AddToSchemes,
-			routeV1.AddToScheme,
-			templateV1.AddToScheme,
+			routeV1.Install,
+			templateV1.Install,
+			oauthv1.Install,
 		)
 	}
 }

--- a/pkg/apis/workspace/v1alpha1/common.go
+++ b/pkg/apis/workspace/v1alpha1/common.go
@@ -46,7 +46,7 @@ type PodAdditions struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	PullSecrets []v1.LocalObjectReference `json:"pullSecrets,omitempty"`
-	// Annotations for the workspace service account, required for e.g. OpenShift oauth
+	// Annotations for the workspace service account, it might be used for e.g. OpenShift oauth with SA as auth client
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge

--- a/pkg/controller/workspacerouting/solvers/oauth_proxy_container.go
+++ b/pkg/controller/workspacerouting/solvers/oauth_proxy_container.go
@@ -54,7 +54,7 @@ func buildSecretVolume(secretName string) corev1.Volume {
 }
 
 func getProxyContainerForEndpoint(proxyEndpoint proxyEndpoint, tlsProxyVolume corev1.Volume, meta WorkspaceMetadata) corev1.Container {
-	proxyContainerName := fmt.Sprintf("%s-oauth-proxy-%s", meta.WorkspaceId, strconv.FormatInt(proxyEndpoint.upstreamEndpoint.Port, 10))
+	proxyContainerName := fmt.Sprintf("oauth-proxy-%s", strconv.FormatInt(proxyEndpoint.upstreamEndpoint.Port, 10))
 
 	return corev1.Container{
 		Name: proxyContainerName,
@@ -78,14 +78,15 @@ func getProxyContainerForEndpoint(proxyEndpoint proxyEndpoint, tlsProxyVolume co
 			"--https-address=:" + strconv.FormatInt(proxyEndpoint.publicEndpoint.Port, 10),
 			"--http-address=127.0.0.1:" + strconv.FormatInt(proxyEndpoint.publicEndpointHttpPort, 10),
 			"--provider=openshift",
-			"--openshift-service-account=" + common.ServiceAccountName(meta.WorkspaceId),
 			"--upstream=http://localhost:" + strconv.FormatInt(proxyEndpoint.upstreamEndpoint.Port, 10),
 			"--tls-cert=/etc/tls/private/tls.crt",
 			"--tls-key=/etc/tls/private/tls.key",
 			"--cookie-secret=0123456789abcdefabcd",
+			"--client-id=" + meta.WorkspaceId + "-oauth-client",
+			"--client-secret=1234567890",
 			"--pass-user-bearer-token=false",
 			"--pass-access-token=true",
-			"--scope=user:info user:check-access role:pods-exec:" + meta.Namespace,
+			"--scope=user:full",
 		},
 	}
 }

--- a/pkg/controller/workspacerouting/solvers/solver.go
+++ b/pkg/controller/workspacerouting/solvers/solver.go
@@ -14,6 +14,7 @@ package solvers
 
 import (
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	routeV1 "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -24,6 +25,7 @@ type RoutingObjects struct {
 	Ingresses    []v1beta1.Ingress
 	Routes       []routeV1.Route
 	PodAdditions *v1alpha1.PodAdditions
+	OAuthClient  *oauthv1.OAuthClient
 }
 
 type RoutingSolver interface {

--- a/pkg/controller/workspacerouting/sync_oauthclients.go
+++ b/pkg/controller/workspacerouting/sync_oauthclients.go
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspacerouting
+
+import (
+	"context"
+	"fmt"
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var oauthClientDiffOpts = cmp.Options{
+	cmpopts.IgnoreFields(oauthv1.OAuthClient{}, "TypeMeta", "ObjectMeta"),
+}
+
+func (r *ReconcileWorkspaceRouting) syncOAuthClient(routing *v1alpha1.WorkspaceRouting, oauthClientSpec oauthv1.OAuthClient) (ok bool, err error) {
+	oauthClientInSync := true
+
+	clusterOAuthClients, err := r.getClusterOAuthClients(routing)
+	if err != nil {
+		return false, err
+	}
+
+	var clusterOAuthClient *oauthv1.OAuthClient
+	var toDelete []oauthv1.OAuthClient
+	for _, o := range clusterOAuthClients {
+		if o.Name == oauthClientSpec.Name {
+			clusterOAuthClient = &o
+		} else {
+			toDelete = append(toDelete, o)
+		}
+	}
+
+	for _, route := range toDelete {
+		err := r.client.Delete(context.TODO(), &route)
+		if err != nil {
+			return false, err
+		}
+		oauthClientInSync = false
+	}
+
+	if clusterOAuthClient != nil {
+		if !cmp.Equal(oauthClientSpec, clusterOAuthClient, oauthClientDiffOpts) {
+			// Update oauth client
+			clusterOAuthClient.Secret = oauthClientSpec.Secret
+			clusterOAuthClient.Labels = oauthClientSpec.Labels
+			clusterOAuthClient.GrantMethod = oauthClientSpec.GrantMethod
+			clusterOAuthClient.RedirectURIs = oauthClientSpec.RedirectURIs
+			err := r.client.Update(context.TODO(), clusterOAuthClient)
+			if err != nil && !apierrors.IsConflict(err) {
+				return false, err
+			}
+
+			oauthClientInSync = false
+		}
+	} else {
+		err = r.client.Create(context.TODO(), &oauthClientSpec)
+
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return true, nil
+			}
+			return false, err
+		}
+	}
+
+	return oauthClientInSync, nil
+}
+
+func (r *ReconcileWorkspaceRouting) getClusterOAuthClients(routing *v1alpha1.WorkspaceRouting) ([]oauthv1.OAuthClient, error) {
+	found := &oauthv1.OAuthClientList{}
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", config.WorkspaceIDLabel, routing.Spec.WorkspaceId))
+	if err != nil {
+		return nil, err
+	}
+	listOptions := &client.ListOptions{
+		Namespace:     routing.Namespace,
+		LabelSelector: labelSelector,
+	}
+	err = r.client.List(context.TODO(), found, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	return found.Items, nil
+}
+
+func (r *ReconcileWorkspaceRouting) deleteOAuthClients(routing *v1alpha1.WorkspaceRouting) error {
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s=%s", config.WorkspaceIDLabel, routing.Spec.WorkspaceId))
+	if err != nil {
+		return err
+	}
+	listOptions := &client.DeleteAllOfOptions{
+		ListOptions: *&client.ListOptions{
+			Namespace:     routing.Namespace,
+			LabelSelector: labelSelector,
+		},
+	}
+	return r.client.DeleteAllOf(context.TODO(), &oauthv1.OAuthClient{}, listOptions)
+}

--- a/pkg/controller/workspacerouting/sync_oauthclients.go
+++ b/pkg/controller/workspacerouting/sync_oauthclients.go
@@ -113,7 +113,6 @@ func (r *ReconcileWorkspaceRouting) deleteOAuthClients(routing *v1alpha1.Workspa
 	}
 	listOptions := &client.DeleteAllOfOptions{
 		ListOptions: client.ListOptions{
-			Namespace:     routing.Namespace,
 			LabelSelector: labelSelector,
 		},
 	}


### PR DESCRIPTION
### What does this PR do?
Use OAuthClient per Workspace to get user:full token with OpenShift OAuth Proxy.

Drawbacks:
- currently, oauthclient secrets are hard-coded but there is a separate issue where this part should be addressed along with cookie-secret;
- Since WorkspaceRouting are namespaced-scoped and OAuthClient are cluster-scoped, WorkspaceRouting can't own OAuthClient. So, I added finalizer and OAuth clients are removed along with workspaces but when OAuthClient are removed or updated - the reconciling loop is not reinvoked. Probably we're able to listen to all OAuthClients as we do with an object owned by us (Workspace,WorkspaceRouting), check if it's workspace-related OAuthClient and reinvoke reconcile loop for WorkspaceRouting. Not sure if we really should implement it. Seems Che Operator does not watch it's oauthclient as well.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16515

### Is it tested? How?
![oauth-client](https://user-images.githubusercontent.com/5887312/78795948-5250de00-79be-11ea-9ced-6de5254dc40f.gif)