### PR TITLE
Update controller cluster role with the state we get after oc apply -f /deploy

### DIFF
--- a/deploy/edit-workspaces-cluster-role.yaml
+++ b/deploy/edit-workspaces-cluster-role.yaml
@@ -10,6 +10,8 @@ rules:
       - workspace.che.eclipse.org
     resources:
       - workspaces
+      - workspaceroutings
+      - components
     verbs:
       - create
       - delete

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: che-workspace-controller
 rules:
 - apiGroups:
@@ -9,7 +8,6 @@ rules:
   resources:
   - pods
   - services
-  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events
@@ -23,6 +21,27 @@ rules:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - update
 - apiGroups:
   - apps
   resources:
@@ -46,8 +65,6 @@ rules:
   verbs:
   - create
   - delete
-  - list
-  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -58,7 +75,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - che-workspace-operator
+  - che-workspace-controller
   resources:
   - deployments/finalizers
   verbs:

--- a/deploy/view-workspaces-cluster-role.yaml
+++ b/deploy/view-workspaces-cluster-role.yaml
@@ -11,6 +11,8 @@ rules:
       - workspace.che.eclipse.org
     resources:
       - workspaces
+      - workspaceroutings
+      - components
     verbs:
       - get
       - list


### PR DESCRIPTION
### What does this PR do?
Now we apply resources with `kc/oc apply -f ./folder/` and it actually process and applies a bit patched object. I have't investigate a reason why it's changed but it's what we have now:
On the left - what we have in config file, on the right - what we have after kc/oc apply -f ./folder/
![Screenshot_20200409_132856](https://user-images.githubusercontent.com/5887312/78885925-15d8bd00-7a66-11ea-9de2-0f535cf442c6.png)

So this PR updates controller cluster role with the state we get after oc apply -f /deploy
Note that `kc/oc apply -f /file` behaves in a bit different way, and with these changes it does not matter if cluster role is applied via folder or file reference.

Master branch:
![Screenshot_20200409_132147](https://user-images.githubusercontent.com/5887312/78885346-19b80f80-7a65-11ea-9350-0d3b9e76daab.png)

This PR:
![Screenshot_20200409_132006](https://user-images.githubusercontent.com/5887312/78885263-f4c39c80-7a64-11ea-9194-34ebe9a34c15.png)

:warning: Probably for us it means that we must do `kc apply -f file` to void side-affects changes we're not aware of. But it can be done separately.

This also add rights to view and edit components and routings.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
Checked that cloud-shell with OpenShift OAuth and webhooks works.
