### PR TITLE
Create routes on OpenShift and ingresses on Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The repository contains a Makefile; building and deploying can be configured via
 |---|---|---|
 | `IMG` | Image used for controller | `quay.io/che-incubator/che-workspace-controller:nightly` |
 | `TOOL` | CLI tool for interfacing with the cluster: `kubectl` or `oc`; if `oc` is used, deployment is tailored to OpenShift, otherwise Kubernetes | `oc` |
-| `CLUSTER_IP` | For Kubernetes only, the ip address of the cluster (`minikube ip`) | `192.168.99.100` |
+| `ROUTING_SUFFIX` | Cluster routing suffix (e.g. `$(minikube ip).nip.io`, `apps-crc.testing`). Required for Kubernetes | `192.168.99.100.nip.io` |
 | `PULL_POLICY` | Image pull policy for controller | `Always` |
 | `WEBHOOK_ENABLED` | Whether webhooks should be enabled in the deployment | `false` |
 | `DEFAULT_ROUTING` | Default routingClass to apply to workspaces that don't specify one | `basic` |

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -5,7 +5,7 @@ metadata:
   name: che-workspace-controller
   namespace: che-workspace-controller
 data:
-  ingress.global.domain: 192.168.99.100.nip.io
+  cluster.routing_suffix: 192.168.99.100.nip.io
   plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
   che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
   cherestapis.image.name: amisevsk/che-rest-apis:v0.0.2

--- a/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
@@ -33,10 +33,6 @@ spec:
           properties:
             endpoints:
               description: Machines to endpoints map
-            ingressGlobalDomain:
-              description: Ingress global domain (corresponds to the OpenShift route
-                suffix)
-              type: string
             podSelector:
               additionalProperties:
                 type: string
@@ -47,13 +43,16 @@ spec:
               description: 'Class of the routing: this drives which Workspace Routing
                 controller will manage this routing'
               type: string
+            routingSuffix:
+              description: Routing suffix for cluster
+              type: string
             workspaceId:
               description: WorkspaceId for the workspace being routed
               type: string
           required:
           - endpoints
-          - ingressGlobalDomain
           - podSelector
+          - routingSuffix
           - workspaceId
           type: object
         status:

--- a/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
@@ -23,8 +23,8 @@ type WorkspaceRoutingSpec struct {
 	WorkspaceId string `json:"workspaceId"`
 	// Class of the routing: this drives which Workspace Routing controller will manage this routing
 	RoutingClass WorkspaceRoutingClass `json:"routingClass,omitempty"`
-	// Ingress global domain (corresponds to the OpenShift route suffix)
-	IngressGlobalDomain string `json:"ingressGlobalDomain"`
+	// Routing suffix for cluster
+	RoutingSuffix string `json:"routingSuffix"`
 	// Machines to endpoints map
 	Endpoints map[string][]Endpoint `json:"endpoints"`
 	// Selector that should be used by created services to point to the workspace Pod

--- a/pkg/apis/workspace/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/workspace/v1alpha1/zz_generated.openapi.go
@@ -276,9 +276,9 @@ func schema_pkg_apis_workspace_v1alpha1_WorkspaceRoutingSpec(ref common.Referenc
 							Format:      "",
 						},
 					},
-					"ingressGlobalDomain": {
+					"routingSuffix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ingress global domain (corresponds to the OpenShift route suffix)",
+							Description: "Routing suffix for cluster",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -320,7 +320,7 @@ func schema_pkg_apis_workspace_v1alpha1_WorkspaceRoutingSpec(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"workspaceId", "ingressGlobalDomain", "endpoints", "podSelector"},
+				Required: []string{"workspaceId", "routingSuffix", "endpoints", "podSelector"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -35,12 +35,12 @@ func ServiceAccountName(workspaceId string) string {
 	return fmt.Sprintf("%s-%s", workspaceId, "sa")
 }
 
-func EndpointHostname(workspaceId, endpointName string, endpointPort int64, ingressGlobalDomain string) string {
+func EndpointHostname(workspaceId, endpointName string, endpointPort int64, routingSuffix string) string {
 	hostname := fmt.Sprintf("%s-%s-%d", workspaceId, endpointName, endpointPort)
 	if len(hostname) > 63 {
 		hostname = strings.TrimSuffix(hostname[:63], "-")
 	}
-	return fmt.Sprintf("%s.%s", hostname, ingressGlobalDomain)
+	return fmt.Sprintf("%s.%s", hostname, routingSuffix)
 }
 
 func RouteName(workspaceId, endpointName string) string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,8 +72,8 @@ func (wc *ControllerConfig) GetPluginRegistry() string {
 	return wc.GetPropertyOrDefault(pluginRegistryURL, "")
 }
 
-func (wc *ControllerConfig) GetIngressGlobalDomain() string {
-	return wc.GetPropertyOrDefault(ingressGlobalDomain, defaultIngressGlobalDomain)
+func (wc *ControllerConfig) GetRoutingSuffix() string {
+	return wc.GetPropertyOrDefault(routingSuffix, defaultRoutingSuffix)
 }
 
 func (wc *ControllerConfig) GetPVCStorageClassName() *string {
@@ -218,7 +218,7 @@ func buildDefaultConfigMap(cm *corev1.ConfigMap) {
 	cm.Namespace = ConfigMapReference.Namespace
 
 	cm.Data = map[string]string{
-		ingressGlobalDomain:        defaultIngressGlobalDomain,
+		routingSuffix:              defaultRoutingSuffix,
 		pluginArtifactsBrokerImage: defaultPluginArtifactsBrokerImage,
 	}
 }
@@ -252,7 +252,7 @@ func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMa
 	host := testRoute.Spec.Host
 	if host != "" {
 		prefixToRemove := "che-workspace-controller-test-route-" + configMap.Namespace + "."
-		configMap.Data["ingress.global.domain"] = strings.TrimPrefix(host, prefixToRemove)
+		configMap.Data[routingSuffix] = strings.TrimPrefix(host, prefixToRemove)
 	}
 
 	err = nonCachedClient.Update(context.TODO(), configMap)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"github.com/che-incubator/che-workspace-operator/internal/cluster"
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
@@ -118,6 +119,13 @@ func (wc *ControllerConfig) GetPropertyOrDefault(name string, defaultValue strin
 		return val
 	}
 	return defaultValue
+}
+
+func (wc *ControllerConfig) Validate() error {
+	if !wc.isOpenShift && wc.GetDefaultRoutingClass() == string(v1alpha1.WorkspaceRoutingOpenShiftOauth) {
+		return fmt.Errorf("controller appears to be running in non-OpenShift cluster, but default routing class is '%s'", v1alpha1.WorkspaceRoutingOpenShiftOauth)
+	}
+	return nil
 }
 
 func updateConfigMap(client client.Client, meta metav1.Object, obj runtime.Object) {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -42,6 +42,9 @@ const (
 	// WorkspaceIDLabel is label key to store workspace identifier
 	WorkspaceIDLabel = "che.workspace_id"
 
+	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
+	WorkspaceEndpointNameAnnotation = "che.workspace.endpoint_name"
+
 	// WorkspaceNameLabel is label key to store workspace identifier
 	WorkspaceNameLabel = "che.workspace_name"
 

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -21,8 +21,8 @@ const (
 
 	pluginRegistryURL = "plugin.registry.url"
 
-	ingressGlobalDomain        = "ingress.global.domain"
-	defaultIngressGlobalDomain = ""
+	routingSuffix        = "cluster.routing_suffix"
+	defaultRoutingSuffix = ""
 
 	// workspacePVCName config property handles the PVC name that should be created and used for all workspaces within one kubernetes namespace
 	workspacePVCName        = "pvc.name"

--- a/pkg/controller/workspace/provision/routing.go
+++ b/pkg/controller/workspace/provision/routing.go
@@ -116,10 +116,10 @@ func getSpecRouting(
 			Namespace: workspace.Namespace,
 		},
 		Spec: v1alpha1.WorkspaceRoutingSpec{
-			WorkspaceId:         workspace.Status.WorkspaceId,
-			RoutingClass:        workspace.Spec.RoutingClass,
-			IngressGlobalDomain: config.ControllerCfg.GetIngressGlobalDomain(),
-			Endpoints:           endpoints,
+			WorkspaceId:   workspace.Status.WorkspaceId,
+			RoutingClass:  workspace.Spec.RoutingClass,
+			RoutingSuffix: config.ControllerCfg.GetRoutingSuffix(),
+			Endpoints:     endpoints,
 			PodSelector: map[string]string{
 				config.WorkspaceIDLabel: workspace.Status.WorkspaceId,
 			},

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -116,6 +116,12 @@ func add(mgr manager.Manager, r *ReconcileWorkspace) error {
 	}
 	config.ControllerCfg.SetIsOpenShift(isOS)
 
+	err = config.ControllerCfg.Validate()
+	if err != nil {
+		log.Error(err, "Controller configuration is invalid")
+		return err
+	}
+
 	// Redirect standard logging to the reconcile's log
 	// Necessary as e.g. the plugin broker logs to stdout
 	origLog.SetOutput(r)

--- a/pkg/controller/workspacerouting/resolve_endpoints.go
+++ b/pkg/controller/workspacerouting/resolve_endpoints.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package workspacerouting
+
+import (
+	"fmt"
+	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	routeV1 "github.com/openshift/api/route/v1"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+func getExposedEndpoints(
+	endpoints map[string][]workspacev1alpha1.Endpoint,
+	ingresses []v1beta1.Ingress,
+	routes []routeV1.Route) (exposedEndpoints map[string][]workspacev1alpha1.ExposedEndpoint, ready bool, err error) {
+
+	exposedEndpoints = map[string][]workspacev1alpha1.ExposedEndpoint{}
+	ready = true
+
+	for machineName, machineEndpoints := range endpoints {
+		for _, endpoint := range machineEndpoints {
+			if endpoint.Attributes[workspacev1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE] != "true" {
+				continue
+			}
+			url, err := getURLforEndpoint(endpoint, ingresses, routes)
+			if err != nil {
+				return nil, false, err
+			}
+			if url == "" {
+				ready = false
+			}
+			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], workspacev1alpha1.ExposedEndpoint{
+				Name:       endpoint.Name,
+				Url:        url,
+				Attributes: endpoint.Attributes,
+			})
+		}
+	}
+	return exposedEndpoints, ready, nil
+}
+
+func getURLforEndpoint(
+	endpoint workspacev1alpha1.Endpoint,
+	ingresses []v1beta1.Ingress,
+	routes []routeV1.Route) (string, error) {
+	for _, route := range routes {
+		if route.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
+			protocol := endpoint.Attributes[workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE]
+			if endpoint.Attributes[workspacev1alpha1.SECURE_ENDPOINT_ATTRIBUTE] == "true" &&
+				route.Spec.TLS != nil {
+				protocol = getSecureProtocol(protocol)
+			}
+			url := fmt.Sprintf("%s://%s", protocol, route.Spec.Host)
+			return url, nil
+		}
+	}
+	for _, ingress := range ingresses {
+		if ingress.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
+			if len(ingress.Spec.Rules) == 1 {
+				protocol := endpoint.Attributes[workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE]
+				url := fmt.Sprintf("%s://%s", protocol, ingress.Spec.Rules[0].Host)
+				return url, nil
+			} else {
+				return "", fmt.Errorf("ingress %s contains multiple rules", ingress.Name)
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find ingress/route for endpoint '%s'", endpoint.Name)
+}

--- a/pkg/controller/workspacerouting/solvers/basic_solver.go
+++ b/pkg/controller/workspacerouting/solvers/basic_solver.go
@@ -29,11 +29,11 @@ var _ RoutingSolver = (*BasicSolver)(nil)
 func (s *BasicSolver) GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec, workspaceMeta WorkspaceMetadata) RoutingObjects {
 	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
 	services = append(services, getDiscoverableServicesForEndpoints(spec.Endpoints, workspaceMeta)...)
-	ingresses, exposedEndpoints := getIngressesForSpec(spec.Endpoints, workspaceMeta)
+	ingresses, routes := getRoutingForSpec(spec.Endpoints, workspaceMeta)
 
 	return RoutingObjects{
-		Services:         services,
-		Ingresses:        ingresses,
-		ExposedEndpoints: exposedEndpoints,
+		Services:  services,
+		Ingresses: ingresses,
+		Routes:    routes,
 	}
 }

--- a/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -56,10 +56,10 @@ func (s *OpenShiftOAuthSolver) GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec
 	routes, podAdditions := s.getProxyRoutes(proxy, workspaceMeta, portMappings)
 
 	return RoutingObjects{
-		Services:         services,
-		Ingresses:        defaultIngresses,
-		Routes:           append(routes, defaultRoutes...),
-		PodAdditions:     podAdditions,
+		Services:     services,
+		Ingresses:    defaultIngresses,
+		Routes:       append(routes, defaultRoutes...),
+		PodAdditions: podAdditions,
 	}
 }
 

--- a/pkg/controller/workspacerouting/solvers/solver.go
+++ b/pkg/controller/workspacerouting/solvers/solver.go
@@ -24,7 +24,6 @@ type RoutingObjects struct {
 	Ingresses        []v1beta1.Ingress
 	Routes           []routeV1.Route
 	PodAdditions     *v1alpha1.PodAdditions
-	ExposedEndpoints map[string][]v1alpha1.ExposedEndpoint
 }
 
 type RoutingSolver interface {

--- a/pkg/controller/workspacerouting/solvers/solver.go
+++ b/pkg/controller/workspacerouting/solvers/solver.go
@@ -20,10 +20,10 @@ import (
 )
 
 type RoutingObjects struct {
-	Services         []v1.Service
-	Ingresses        []v1beta1.Ingress
-	Routes           []routeV1.Route
-	PodAdditions     *v1alpha1.PodAdditions
+	Services     []v1.Service
+	Ingresses    []v1beta1.Ingress
+	Routes       []routeV1.Route
+	PodAdditions *v1alpha1.PodAdditions
 }
 
 type RoutingSolver interface {

--- a/pkg/controller/workspacerouting/sync_ingresses.go
+++ b/pkg/controller/workspacerouting/sync_ingresses.go
@@ -67,7 +67,7 @@ func (r *ReconcileWorkspaceRouting) syncIngresses(routing *v1alpha1.WorkspaceRou
 		}
 	}
 
-	return ingressesInSync, clusterIngresses,nil
+	return ingressesInSync, clusterIngresses, nil
 }
 
 func (r *ReconcileWorkspaceRouting) getClusterIngresses(routing *v1alpha1.WorkspaceRouting) ([]v1beta1.Ingress, error) {

--- a/pkg/controller/workspacerouting/sync_routes.go
+++ b/pkg/controller/workspacerouting/sync_routes.go
@@ -74,7 +74,7 @@ func (r *ReconcileWorkspaceRouting) syncRoutes(routing *v1alpha1.WorkspaceRoutin
 		}
 	}
 
-	return routesInSync, clusterRoutes,nil
+	return routesInSync, clusterRoutes, nil
 }
 
 func (r *ReconcileWorkspaceRouting) getClusterRoutes(routing *v1alpha1.WorkspaceRouting) ([]routeV1.Route, error) {

--- a/pkg/controller/workspacerouting/workspacerouting_controller.go
+++ b/pkg/controller/workspacerouting/workspacerouting_controller.go
@@ -187,7 +187,7 @@ func (r *ReconcileWorkspaceRouting) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{Requeue: true}, err
 	}
 
-	exposedEndpoints, endpointsReady, err := getExposedEndpoints(instance.Spec.Endpoints, clusterIngresses, clusterRoutes)
+	exposedEndpoints, endpointsAreReady, err := getExposedEndpoints(instance.Spec.Endpoints, clusterIngresses, clusterRoutes)
 	if err != nil {
 		reqLogger.Error(err, "Could not get exposed endpoints for workspace")
 		instance.Status.Phase = workspacev1alpha1.RoutingFailed
@@ -195,7 +195,7 @@ func (r *ReconcileWorkspaceRouting) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, statusErr
 	}
 
-	return reconcile.Result{}, r.reconcileStatus(instance, routingObjects, exposedEndpoints, endpointsReady)
+	return reconcile.Result{}, r.reconcileStatus(instance, routingObjects, exposedEndpoints, endpointsAreReady)
 }
 
 func (r *ReconcileWorkspaceRouting) reconcileStatus(
@@ -217,65 +217,6 @@ func (r *ReconcileWorkspaceRouting) reconcileStatus(
 	instance.Status.PodAdditions = routingObjects.PodAdditions
 	instance.Status.ExposedEndpoints = exposedEndpoints
 	return r.client.Status().Update(context.TODO(), instance)
-}
-
-func getExposedEndpoints(
-	endpoints map[string][]workspacev1alpha1.Endpoint,
-	ingresses []v1beta1.Ingress,
-	routes []routeV1.Route) (exposedEndpoints map[string][]workspacev1alpha1.ExposedEndpoint, ready bool, err error) {
-
-	exposedEndpoints = map[string][]workspacev1alpha1.ExposedEndpoint{}
-	ready = true
-
-	for machineName, machineEndpoints := range endpoints {
-		for _, endpoint := range machineEndpoints {
-			if endpoint.Attributes[workspacev1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE] != "true" {
-				continue
-			}
-			url, err := getURLforEndpoint(endpoint, ingresses, routes)
-			if err != nil {
-				return nil, false, err
-			}
-			if url == "" {
-				ready = false
-			}
-			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], workspacev1alpha1.ExposedEndpoint{
-				Name:       endpoint.Name,
-				Url:        url,
-				Attributes: endpoint.Attributes,
-			})
-		}
-	}
-	return exposedEndpoints, ready, nil
-}
-
-func getURLforEndpoint(
-	endpoint workspacev1alpha1.Endpoint,
-	ingresses []v1beta1.Ingress,
-	routes []routeV1.Route) (string, error) {
-	for _, route := range routes {
-		if route.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
-			protocol := endpoint.Attributes[workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE]
-			if endpoint.Attributes[workspacev1alpha1.SECURE_ENDPOINT_ATTRIBUTE] == "true" &&
-				route.Spec.TLS != nil {
-				protocol = getSecureProtocol(protocol)
-			}
-			url := fmt.Sprintf("%s://%s", protocol, route.Spec.Host)
-			return url, nil
-		}
-	}
-	for _, ingress := range ingresses {
-		if ingress.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
-			if len(ingress.Spec.Rules) == 1 {
-				protocol := endpoint.Attributes[workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE]
-				url := fmt.Sprintf("%s://%s", protocol, ingress.Spec.Rules[0].Host)
-				return url, nil
-			} else {
-				return "", fmt.Errorf("ingress %s contains multiple rules", ingress.Name)
-			}
-		}
-	}
-	return "", fmt.Errorf("could not find ingress/route for endpoint '%s'", endpoint.Name)
 }
 
 func getSolverForRoutingClass(routingClass workspacev1alpha1.WorkspaceRoutingClass) (solvers.RoutingSolver, error) {

--- a/pkg/controller/workspacerouting/workspacerouting_controller.go
+++ b/pkg/controller/workspacerouting/workspacerouting_controller.go
@@ -195,12 +195,12 @@ func (r *ReconcileWorkspaceRouting) Reconcile(request reconcile.Request) (reconc
 }
 
 func (r *ReconcileWorkspaceRouting) reconcileStatus(
-		instance *workspacev1alpha1.WorkspaceRouting,
-		routingObjects solvers.RoutingObjects,
-		exposedEndpoints map[string][]workspacev1alpha1.ExposedEndpoint) error {
+	instance *workspacev1alpha1.WorkspaceRouting,
+	routingObjects solvers.RoutingObjects,
+	exposedEndpoints map[string][]workspacev1alpha1.ExposedEndpoint) error {
 	if instance.Status.Phase == workspacev1alpha1.RoutingReady &&
-			cmp.Equal(instance.Status.PodAdditions, routingObjects.PodAdditions) &&
-			cmp.Equal(instance.Status.ExposedEndpoints, exposedEndpoints) {
+		cmp.Equal(instance.Status.PodAdditions, routingObjects.PodAdditions) &&
+		cmp.Equal(instance.Status.ExposedEndpoints, exposedEndpoints) {
 		return nil
 	}
 	instance.Status.Phase = workspacev1alpha1.RoutingReady
@@ -210,9 +210,9 @@ func (r *ReconcileWorkspaceRouting) reconcileStatus(
 }
 
 func getExposedEndpoints(
-		endpoints map[string][]workspacev1alpha1.Endpoint,
-		ingresses []v1beta1.Ingress,
-		routes []routeV1.Route) (map[string][]workspacev1alpha1.ExposedEndpoint, error) {
+	endpoints map[string][]workspacev1alpha1.Endpoint,
+	ingresses []v1beta1.Ingress,
+	routes []routeV1.Route) (map[string][]workspacev1alpha1.ExposedEndpoint, error) {
 	exposedEndpoints := map[string][]workspacev1alpha1.ExposedEndpoint{}
 
 	for machineName, machineEndpoints := range endpoints {
@@ -235,14 +235,14 @@ func getExposedEndpoints(
 }
 
 func getURLforEndpoint(
-		endpoint workspacev1alpha1.Endpoint,
-		ingresses []v1beta1.Ingress,
-		routes []routeV1.Route) (string, error) {
+	endpoint workspacev1alpha1.Endpoint,
+	ingresses []v1beta1.Ingress,
+	routes []routeV1.Route) (string, error) {
 	for _, route := range routes {
 		if route.Annotations[config.WorkspaceEndpointNameAnnotation] == endpoint.Name {
 			protocol := endpoint.Attributes[workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE]
 			if endpoint.Attributes[workspacev1alpha1.SECURE_ENDPOINT_ATTRIBUTE] == "true" &&
-					route.Spec.TLS != nil {
+				route.Spec.TLS != nil {
 				protocol = getSecureProtocol(protocol)
 			}
 			url := fmt.Sprintf("%s://%s", protocol, route.Spec.Host)
@@ -289,4 +289,3 @@ func getSecureProtocol(protocol string) string {
 		return protocol
 	}
 }
-


### PR DESCRIPTION
### What does this PR do?
Change WorkspaceRoutings controller to always create routes on OpenShift and ingresses on Kubernetes.

One of the goals in this PR was to eliminate the need for `ingress.global.domain` when running on OpenShift by not specifying hostnames when creating routes. However, OpenShift's automatically-generated route hostnames are `<route-name>-<namespace>.<routing-suffix>`, which means they're frequently invalid (if e.g. deployed in namespace `che-workspace-controller`. As a result, I've renamed `ingress.global.domain` to `cluster.routing.suffix` and added setting the value via the makefile.

Note: the controller does contain logic to [automatically set routing suffix](https://github.com/che-incubator/che-workspace-operator/blob/ae2b1ca06f69b3ad6d4ed245e7483f8637e70be9/pkg/config/config.go#L226) on OpenShift; however, I have had it fail/fall out of sync in the past so the separate option is still useful.

### Is it tested? How?
Tested on `crc` with the usual matrix of settings. Have not currently tested on minikube but will before merge.