### PR TITLE
Use goimports if available for make fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,13 @@ start_local_debug:
 
 ### fmt: format all go files in repository
 fmt:
+ifneq ($(shell command -v goimports 2> /dev/null),)
+	find . -name '*.go' -exec goimports -w {} \;
+else
+	@echo "WARN: goimports is not installed -- formatting using go fmt instead."
+	@echo "      Please install goimports to ensure file imports are consistent."
 	go fmt -x ./...
+endif
 
 .PHONY: help
 ### help: print this message

--- a/pkg/adaptor/artifacts_broker.go
+++ b/pkg/adaptor/artifacts_broker.go
@@ -15,6 +15,7 @@ package adaptor
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"

--- a/pkg/adaptor/common.go
+++ b/pkg/adaptor/common.go
@@ -14,6 +14,7 @@ package adaptor
 
 import (
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/adaptor/dockerimage.go
+++ b/pkg/adaptor/dockerimage.go
@@ -14,11 +14,12 @@ package adaptor
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 func AdaptDockerimageComponents(workspaceId string, devfileComponents []v1alpha1.ComponentSpec, commands []v1alpha1.CommandSpec) ([]v1alpha1.ComponentDescription, error) {

--- a/pkg/apis/workspace/v1alpha1/common.go
+++ b/pkg/apis/workspace/v1alpha1/common.go
@@ -12,7 +12,7 @@
 
 package v1alpha1
 
-import "k8s.io/api/core/v1"
+import v1 "k8s.io/api/core/v1"
 
 // Summary of additions that are to be merged into the main workspace deployment
 type PodAdditions struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,11 +15,12 @@ package config
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
-	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 
 	routeV1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -15,6 +15,7 @@ package component
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/adaptor"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/workspace/prerequisites/check_prerequisites.go
+++ b/pkg/controller/workspace/prerequisites/check_prerequisites.go
@@ -14,6 +14,8 @@ package prerequisites
 
 import (
 	"context"
+	"reflect"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/controller/workspace/provision/components.go
+++ b/pkg/controller/workspace/provision/components.go
@@ -15,6 +15,7 @@ package provision
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/adaptor"
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -15,6 +15,8 @@ package provision
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/env"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
 )
 
 type DeploymentProvisioningStatus struct {

--- a/pkg/controller/workspace/provision/routing.go
+++ b/pkg/controller/workspace/provision/routing.go
@@ -15,6 +15,7 @@ package provision
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/workspace/provision/serviceaccount.go
+++ b/pkg/controller/workspace/provision/serviceaccount.go
@@ -14,6 +14,7 @@ package provision
 
 import (
 	"context"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/workspace/restapis/configmap.go
+++ b/pkg/controller/workspace/restapis/configmap.go
@@ -15,6 +15,7 @@ package restapis
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"

--- a/pkg/controller/workspace/status.go
+++ b/pkg/controller/workspace/status.go
@@ -15,14 +15,15 @@ package workspace
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/provision"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeclock "k8s.io/apimachinery/pkg/util/clock"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sort"
-	"strings"
 )
 
 // clock is used to set status condition timestamps.

--- a/pkg/controller/workspace/workspace_controller.go
+++ b/pkg/controller/workspace/workspace_controller.go
@@ -15,10 +15,11 @@ package workspace
 import (
 	"context"
 	"fmt"
-	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/restapis"
 	origLog "log"
 	"os"
 	"strings"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/restapis"
 
 	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"

--- a/pkg/controller/workspacerouting/resolve_endpoints.go
+++ b/pkg/controller/workspacerouting/resolve_endpoints.go
@@ -14,6 +14,7 @@ package workspacerouting
 
 import (
 	"fmt"
+
 	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	routeV1 "github.com/openshift/api/route/v1"

--- a/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -14,6 +14,7 @@ package solvers
 
 import (
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"

--- a/pkg/controller/workspacerouting/solvers/solver.go
+++ b/pkg/controller/workspacerouting/solvers/solver.go
@@ -15,7 +15,7 @@ package solvers
 import (
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	routeV1 "github.com/openshift/api/route/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 )
 

--- a/pkg/controller/workspacerouting/sync_ingresses.go
+++ b/pkg/controller/workspacerouting/sync_ingresses.go
@@ -15,6 +15,7 @@ package workspacerouting
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/workspacerouting/sync_routes.go
+++ b/pkg/controller/workspacerouting/sync_routes.go
@@ -15,6 +15,7 @@ package workspacerouting
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"

--- a/pkg/controller/workspacerouting/sync_services.go
+++ b/pkg/controller/workspacerouting/sync_services.go
@@ -15,6 +15,8 @@ package workspacerouting
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/google/go-cmp/cmp"
@@ -23,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
 var serviceDiffOpts = cmp.Options{

--- a/pkg/controller/workspacerouting/workspacerouting_controller.go
+++ b/pkg/controller/workspacerouting/workspacerouting_controller.go
@@ -15,6 +15,7 @@ package workspacerouting
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/internal/cluster"
 	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -11,10 +11,11 @@
 package server
 
 import (
-	"github.com/che-incubator/che-workspace-operator/internal/cluster"
-	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"io/ioutil"
 	"os"
+
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -13,6 +13,7 @@ package webhook
 
 import (
 	"context"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/pkg/webhook/workspace/config.go
+++ b/pkg/webhook/workspace/config.go
@@ -13,6 +13,7 @@ package workspace
 
 import (
 	"context"
+
 	"github.com/che-incubator/che-workspace-operator/internal/controller"
 	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
 	"k8s.io/api/admissionregistration/v1beta1"

--- a/pkg/webhook/workspace/handler/deployment.go
+++ b/pkg/webhook/workspace/handler/deployment.go
@@ -12,9 +12,10 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 

--- a/pkg/webhook/workspace/handler/exec.go
+++ b/pkg/webhook/workspace/handler/exec.go
@@ -12,11 +12,12 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 

--- a/pkg/webhook/workspace/handler/handler.go
+++ b/pkg/webhook/workspace/handler/handler.go
@@ -14,8 +14,9 @@ package handler
 
 import (
 	"encoding/json"
-	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )

--- a/pkg/webhook/workspace/handler/metadata.go
+++ b/pkg/webhook/workspace/handler/metadata.go
@@ -12,6 +12,7 @@ package handler
 
 import (
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/webhook/workspace/handler/pod.go
+++ b/pkg/webhook/workspace/handler/pod.go
@@ -12,9 +12,10 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 

--- a/pkg/webhook/workspace/handler/workspace.go
+++ b/pkg/webhook/workspace/handler/workspace.go
@@ -13,10 +13,11 @@ package handler
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 

--- a/pkg/webhook/workspace/mutate.go
+++ b/pkg/webhook/workspace/mutate.go
@@ -13,6 +13,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/webhook/workspace/handler"
 	"k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/webhook/workspace/validate.go
+++ b/pkg/webhook/workspace/validate.go
@@ -13,6 +13,7 @@ package workspace
 import (
 	"context"
 	"fmt"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/webhook/workspace/handler"
 	"k8s.io/api/admission/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
### What does this PR do?
Change the tool used for `make fmt` to use `goimports` if available. This is helpful because the default formatter used in the VS Code go plugin is `goreturns`, which executes `goimports`, causing spurious file changes whenever a file is saved. This PR also includes the changes introduced by running the new `make fmt`; as you can see almost every file is modified.

If `goimports` is not installed, use `gofmt` and print an error.

### Is it tested? How?
Tested on Linux (Fedora)
