### PR TITLE
Initialize KubeConfig in Containers

### DIFF
--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -26,3 +26,6 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
      ports:
        - exposedPort: 4444
+     env:
+       - name: KUBECONFIG
+         value: /tmp/.kube/config

--- a/samples/cloud-shell.yaml
+++ b/samples/cloud-shell.yaml
@@ -20,3 +20,5 @@ spec:
         env:
           - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
             name: PS1
+          - name: KUBECONFIG
+            value: /tmp/.kube/config


### PR DESCRIPTION
### What does this PR do?
~~This PR does two things:~~
~~1. Mounts a empty dir volume where the kubeconfig is going to live (config lives at `/tmp/.kube/config` by default), this basically makes it so that we know /tmp/.kube will exist when we are creating the kubeconfig in che-machine-exec~~
~~2. Sets the kubeconfig Env variable that will be propagated to the containers in the workspace pod.~~

This PR has been changed so that both the meta.yaml and the cloud-shell devfile set the KubeConfig Env variable. The Env variable is needed in the meta.yaml so that che-machine-exec will know where to create the kubeconfig. The kubeconfig in the cloud-shell devfile is set so that oc/kubectl knows where the kubeconfig is. Since che-machine-exec is doing the creating of the kubeconfig, the volume allows the configs to be shared between che-machine-exec container and the dev container. The volume and volumeMounts are now only added when KUBECONFIG env variable is set.

The creation of the kubeconfig itself had to be done on che-machine-exec side: https://github.com/eclipse/che-machine-exec/pull/95

Before:
![cloud-shell-before](https://user-images.githubusercontent.com/8839537/80132669-04b1a500-856a-11ea-9bc8-9adcdc720e34.gif)

After:
![cloud-shell-after](https://user-images.githubusercontent.com/8839537/80132666-04b1a500-856a-11ea-9cf8-8a7c60ce2473.gif)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16576

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested on CRC with webhooks enabled + openshift-oauth and replaced the che-machine-exec image in the internal registry to be `jpinkney/che-machine-exec:latest`
