### PR TITLE
Add an ability to configure path for endpoint

### DIFF
--- a/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
+++ b/internal-registry/eclipse/cloud-shell/nightly/meta.yaml
@@ -18,6 +18,7 @@ spec:
       attributes:
         protocol: http
         type: ide
+        path: /static/
         discoverable: false
         secure: true
         cookiesAuthEnabled: true

--- a/pkg/apis/workspace/v1alpha1/devfile.go
+++ b/pkg/apis/workspace/v1alpha1/devfile.go
@@ -108,6 +108,9 @@ const (
 	//endpoint attribute that indicates which protocol is used by backend application
 	PROTOCOL_ENDPOINT_ATTRIBUTE EndpointAttribute = "protocol"
 
+	//endpoint attribute that indicates which path should be used by default to access an application
+	PATH_ENDPOINT_ATTRIBUTE EndpointAttribute = "path"
+
 	DISCOVERABLE_ATTRIBUTE EndpointAttribute = "discoverable"
 )
 

--- a/pkg/controller/workspacerouting/resolve_endpoints.go
+++ b/pkg/controller/workspacerouting/resolve_endpoints.go
@@ -14,7 +14,7 @@ package workspacerouting
 
 import (
 	"fmt"
-	"strings"
+	"net/url"
 
 	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
@@ -79,10 +79,10 @@ func getURLForEndpoint(endpoint workspacev1alpha1.Endpoint, host string, secure 
 		protocol = getSecureProtocol(protocol)
 	}
 	path := endpoint.Attributes[workspacev1alpha1.PATH_ENDPOINT_ATTRIBUTE]
-	if path != "" {
-		if !strings.HasPrefix(path, "/") {
-			path = "/" + path
-		}
+	u := url.URL{
+		Scheme: protocol,
+		Host:   host,
+		Path:   path,
 	}
-	return fmt.Sprintf("%s://%s%s", protocol, host, path)
+	return u.String()
 }


### PR DESCRIPTION
### What does this PR do?
It's needed for proxied cloud shell via OpenShift Console proxy to avoid absolute redirection from `/` to `/static`. Since CloudShell Server Side is under reverse proxy, and the path is rewritten - it's not possible to send right redirection, so the only way - go to right endpoint path from the beginning 

Note that such a feature is already supported by Che Server.

### What issues does this PR fix or reference?
It's done during an investigation for https://github.com/eclipse/che/issues/16633

### Is it tested? How?
I did not manage to test it with OpenShift OAuth Proxy, my crc is got crazy and OpenShift OAuth Proxy can't access OS API. I hope to retest it later.

But I tested the following with basic routing on crc
1. Run CloudShell.
2. Open IDE URL of running workspace.
3. Make sure the CloudShell is opened without absolute redirection.
![Screenshot_20200427_182646](https://user-images.githubusercontent.com/5887312/80390109-aad81480-88b4-11ea-8182-f8d7b528476d.png)

