### PR TITLE
Remove clusterroles and bindings when uninstalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ ifneq ($(TOOL) get workspaces.workspace.che.eclipse.org --all-namespaces,"No res
 	$(error Cannot uninstall operator, workspaces still running. Delete all workspaces and workspaceroutings before proceeding)
 endif
 endif
+	$(TOOL) delete -f ./deploy
 	$(TOOL) delete namespace $(NAMESPACE)
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.workspace.che.eclipse.org
 	$(TOOL) delete customresourcedefinitions.apiextensions.k8s.io components.workspace.che.eclipse.org


### PR DESCRIPTION
### What does this PR do?
Add removal of clusterroles and clusterrolebindings to 'uninstall' makefile target.

### What issues does this PR fix or reference?
Currently, after executing `make uninstall`, clusterroles and bindings are left on the cluster. As https://github.com/che-incubator/che-workspace-operator/pull/57 updated which roles are provisioned, it's probably a good idea to reset cluster state to avoid issues (e.g. the view-all rolebinding was removed and could cause issues).

### Is it tested? How?
Tested `make uninstall` on crc.
