### PR TITLE
[proposal] Add annotation to controller to support immutable workspaces

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -52,6 +52,8 @@ const (
 	CheOriginalNameLabel = "che.original_name"
 
 	WorkspaceCreatorAnnotation = "org.eclipse.che.workspace/creator"
+
+	WorkspaceImmutableAnnotation = "org.eclipse.che.workspace/immutable"
 )
 
 // Constants for che-rest-apis

--- a/pkg/webhook/workspace/handler/workspace.go
+++ b/pkg/webhook/workspace/handler/workspace.go
@@ -45,6 +45,10 @@ func (h *WebhookHandler) MutateWorkspaceOnUpdate(_ context.Context, req admissio
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+	immutable := oldWksp.Annotations[config.WorkspaceImmutableAnnotation]
+	if immutable == "true" {
+		return admission.Denied(fmt.Sprintf("workspace '%s' is immutable. To make modifications it must be deleted and recreated", oldWksp.Name))
+	}
 
 	oldCreator, found := oldWksp.Annotations[config.WorkspaceCreatorAnnotation]
 	if !found {


### PR DESCRIPTION
### What does this PR do?
Add annotation org.eclipse.che.workspace/immutable to signify that workspace should not allow further modification, to make secure configuration more persistent.

Once added, further modifications to workspaces are rejected by existing webhooks. If added to a workspace when webhooks are disabled, startup is failed.

### What issues does this PR fix or reference?
We'll likely run into situations where modifications to an existing workspace can be used to extract a user's OpenShift token. This is a first step in preventing that without impacting other flows.

### Is it tested? How?
Tested on crc