### PR TITLE
Limit permissions given to workspace serviceaccount

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -50,13 +50,13 @@ rules:
   verbs:
   - list
   - get
+  - watch
 - apiGroups:
   - apps
+  - extensions
   resources:
   - deployments
-  - daemonsets
   - replicasets
-  - statefulsets
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/controller/workspace/provision/rbac.go
+++ b/pkg/controller/workspace/provision/rbac.go
@@ -35,7 +35,7 @@ func generateRBAC(namespace string) []runtime.Object {
 	return []runtime.Object{
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "exec",
+				Name:      "workspace",
 				Namespace: namespace,
 			},
 			Rules: []rbacv1.PolicyRule{
@@ -44,32 +44,26 @@ func generateRBAC(namespace string) []runtime.Object {
 					APIGroups: []string{""},
 					Verbs:     []string{"create"},
 				},
-			},
-		},
-		&rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      config.ServiceAccount + "-view",
-				Namespace: namespace,
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: "view",
-			},
-			Subjects: []rbacv1.Subject{
 				{
-					Kind: "Group",
-					Name: "system:serviceaccounts:" + namespace,
+					Resources: []string{"pods"},
+					APIGroups: []string{""},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					Resources: []string{"deployments", "replicasets"},
+					APIGroups: []string{"apps", "extensions"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 			},
 		},
 		&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      config.ServiceAccount + "-exec",
+				Name:      config.ServiceAccount + "-workspace",
 				Namespace: namespace,
 			},
 			RoleRef: rbacv1.RoleRef{
 				Kind: "Role",
-				Name: "exec",
+				Name: "workspace",
 			},
 			Subjects: []rbacv1.Subject{
 				{


### PR DESCRIPTION
### What does this PR do?
Limits the permissions granted to the workspace serviceaccount to only what's strictly required (hope I didn't miss something).

### What issues does this PR fix or reference?
Since removing the view clusterrole from the controller serviceaccount, we have an issue where attempting to create a rolebinding that references the view clusterrole is rejected since it's a privilege escalation. Note in this case no error is reported, and instead the create operation is just a no-op.

This is also a valuable change because the previous configuration constitutes a significant privilege escalation risk: if a user creates a workspace in a namespace, they gain the ability to view secrets, etc.

### Is it tested? How?
Tested on `crc`