### PR TITLE
Implement stopped state for workspaces

### DIFF
--- a/pkg/apis/workspace/v1alpha1/component_types.go
+++ b/pkg/apis/workspace/v1alpha1/component_types.go
@@ -56,7 +56,7 @@ type Component struct {
 type ComponentList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items []Component `json:"items"`
+	Items           []Component `json:"items"`
 }
 
 func init() {

--- a/pkg/apis/workspace/v1alpha1/workspace_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspace_types.go
@@ -61,6 +61,7 @@ const (
 	WorkspaceStatusStarting WorkspacePhase = "Starting"
 	WorkspaceStatusRunning  WorkspacePhase = "Running"
 	WorkspaceStatusStopped  WorkspacePhase = "Stopped"
+	WorkspaceStatusStopping WorkspacePhase = "Stopping"
 	WorkspaceStatusFailed   WorkspacePhase = "Failed"
 )
 

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -58,3 +58,7 @@ func PluginBrokerConfigmapName(workspaceId string) string {
 func OAuthProxySecretName(workspaceId string) string {
 	return fmt.Sprintf("%s-%s", workspaceId, "proxy-tls")
 }
+
+func DeploymentName(workspaceId string) string {
+	return workspaceId
+}

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/che-incubator/che-workspace-operator/pkg/common"
+
 	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller/workspace/env"
@@ -144,7 +146,7 @@ func getSpecDeployment(
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      workspace.Status.WorkspaceId,
+			Name:      common.DeploymentName(workspace.Status.WorkspaceId),
 			Namespace: workspace.Namespace,
 			Labels: map[string]string{
 				config.WorkspaceIDLabel: workspace.Status.WorkspaceId,


### PR DESCRIPTION
### What does this PR do?
Add handling for the "Started" field in the workspace CR. If set to false, deployments are scaled to zero and future reconciles do not modify workspace resources.

Stopping a workspace also clears a "failed" status, and can be used to try starting the workspace again.

### What issues does this PR fix or reference?
resolves https://github.com/eclipse/che/issues/16696

### Is it tested? How?
Tested on crc (both basic and openshift-oauth + webhooks):
- stop starting workspace, restart
- stop started workspace, restart
- stop workspace, delete some resources (e.g. deployment, workspacerouting), restart.