### PR TITLE
Update CRDs to support k8s 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ generate:
 ifeq ($(shell operator-sdk version | cut -d , -f 1 | cut -d : -f 2 | cut -d \" -f 2),$(OPERATOR_SDK_VERSION))
 	operator-sdk generate k8s
 	operator-sdk generate crds
+	patch/patch_crds.sh
 else
 	$(error operator-sdk $(OPERATOR_SDK_VERSION) is expected to be used during CRDs and k8s objects generating while $(shell operator-sdk version | cut -d , -f 1 | cut -d : -f 2 | cut -d \" -f 2) found)
 endif

--- a/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
@@ -835,6 +835,7 @@ spec:
                                     type: string
                                 required:
                                   - containerPort
+                                  - protocol
                                 type: object
                               type: array
                               x-kubernetes-list-map-keys:
@@ -1965,6 +1966,7 @@ spec:
                                     type: string
                                 required:
                                   - containerPort
+                                  - protocol
                                 type: object
                               type: array
                               x-kubernetes-list-map-keys:

--- a/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
@@ -51,7 +51,7 @@ spec:
                         workdir:
                           type: string
                       required:
-                      - type
+                        - type
                       type: object
                     type: array
                   attributes:
@@ -61,7 +61,7 @@ spec:
                   name:
                     type: string
                 required:
-                - name
+                  - name
                 type: object
               type: array
             components:
@@ -92,8 +92,8 @@ spec:
                           format: int64
                           type: integer
                       required:
-                      - name
-                      - port
+                        - name
+                        - port
                       type: object
                     type: array
                   env:
@@ -105,8 +105,8 @@ spec:
                         value:
                           type: string
                       required:
-                      - name
-                      - value
+                        - name
+                        - value
                       type: object
                     type: array
                   id:
@@ -136,20 +136,20 @@ spec:
                         name:
                           type: string
                       required:
-                      - containerPath
-                      - name
+                        - containerPath
+                        - name
                       type: object
                     type: array
                 required:
-                - type
+                  - type
                 type: object
               type: array
             workspaceId:
               description: Id of workspace that contains this component
               type: string
           required:
-          - components
-          - workspaceId
+            - components
+            - workspaceId
           type: object
         status:
           description: ComponentStatus defines the observed state of Component
@@ -211,9 +211,9 @@ spec:
                               description: Type of the command
                               type: string
                           required:
-                          - commandLine
-                          - name
-                          - type
+                            - commandLine
+                            - name
+                            - type
                           type: object
                         type: array
                       endpoints:
@@ -232,8 +232,8 @@ spec:
                               format: int64
                               type: integer
                           required:
-                          - name
-                          - port
+                            - name
+                            - port
                           type: object
                         type: array
                     type: object
@@ -324,7 +324,7 @@ spec:
                                               or its key must be defined
                                             type: boolean
                                         required:
-                                        - key
+                                          - key
                                         type: object
                                       fieldRef:
                                         description: 'Selects a field of the pod:
@@ -343,7 +343,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                        - fieldPath
+                                          - fieldPath
                                         type: object
                                       resourceFieldRef:
                                         description: 'Selects a resource of the container:
@@ -358,8 +358,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -369,7 +369,7 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                        - resource
+                                          - resource
                                         type: object
                                       secretKeyRef:
                                         description: Selects a key of a secret in
@@ -391,11 +391,11 @@ spec:
                                               or its key must be defined
                                             type: boolean
                                         required:
-                                        - key
+                                          - key
                                         type: object
                                     type: object
                                 required:
-                                - name
+                                  - name
                                 type: object
                               type: array
                             envFrom:
@@ -513,8 +513,8 @@ spec:
                                                 description: The header field value
                                                 type: string
                                             required:
-                                            - name
-                                            - value
+                                              - name
+                                              - value
                                             type: object
                                           type: array
                                         path:
@@ -523,8 +523,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
@@ -535,7 +535,7 @@ spec:
                                             to the host. Defaults to HTTP.
                                           type: string
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                     tcpSocket:
                                       description: 'TCPSocket specifies an action
@@ -549,15 +549,15 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
                                             be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                   type: object
                                 preStop:
@@ -619,8 +619,8 @@ spec:
                                                 description: The header field value
                                                 type: string
                                             required:
-                                            - name
-                                            - value
+                                              - name
+                                              - value
                                             type: object
                                           type: array
                                         path:
@@ -629,8 +629,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
@@ -641,7 +641,7 @@ spec:
                                             to the host. Defaults to HTTP.
                                           type: string
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                     tcpSocket:
                                       description: 'TCPSocket specifies an action
@@ -655,15 +655,15 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
                                             be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                   type: object
                               type: object
@@ -719,8 +719,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -728,8 +728,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -739,7 +739,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -771,14 +771,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -834,12 +834,12 @@ spec:
                                       or SCTP. Defaults to "TCP".
                                     type: string
                                 required:
-                                - containerPort
+                                  - containerPort
                                 type: object
                               type: array
                               x-kubernetes-list-map-keys:
-                              - containerPort
-                              - protocol
+                                - containerPort
+                                - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
                               description: 'Periodic probe of container service readiness.
@@ -893,8 +893,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -902,8 +902,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -913,7 +913,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -945,14 +945,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -968,8 +968,8 @@ spec:
                                 limits:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Limits describes the maximum amount
@@ -978,8 +978,8 @@ spec:
                                 requests:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Requests describes the minimum amount
@@ -1188,8 +1188,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -1197,8 +1197,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -1208,7 +1208,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -1240,14 +1240,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -1319,8 +1319,8 @@ spec:
                                       in the pod
                                     type: string
                                 required:
-                                - devicePath
-                                - name
+                                  - devicePath
+                                  - name
                                 type: object
                               type: array
                             volumeMounts:
@@ -1364,8 +1364,8 @@ spec:
                                       are mutually exclusive.
                                     type: string
                                 required:
-                                - mountPath
-                                - name
+                                  - mountPath
+                                  - name
                                 type: object
                               type: array
                             workingDir:
@@ -1375,7 +1375,7 @@ spec:
                                 be updated.
                               type: string
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
                       initContainers:
@@ -1454,7 +1454,7 @@ spec:
                                               or its key must be defined
                                             type: boolean
                                         required:
-                                        - key
+                                          - key
                                         type: object
                                       fieldRef:
                                         description: 'Selects a field of the pod:
@@ -1473,7 +1473,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                        - fieldPath
+                                          - fieldPath
                                         type: object
                                       resourceFieldRef:
                                         description: 'Selects a resource of the container:
@@ -1488,8 +1488,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -1499,7 +1499,7 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                        - resource
+                                          - resource
                                         type: object
                                       secretKeyRef:
                                         description: Selects a key of a secret in
@@ -1521,11 +1521,11 @@ spec:
                                               or its key must be defined
                                             type: boolean
                                         required:
-                                        - key
+                                          - key
                                         type: object
                                     type: object
                                 required:
-                                - name
+                                  - name
                                 type: object
                               type: array
                             envFrom:
@@ -1643,8 +1643,8 @@ spec:
                                                 description: The header field value
                                                 type: string
                                             required:
-                                            - name
-                                            - value
+                                              - name
+                                              - value
                                             type: object
                                           type: array
                                         path:
@@ -1653,8 +1653,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
@@ -1665,7 +1665,7 @@ spec:
                                             to the host. Defaults to HTTP.
                                           type: string
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                     tcpSocket:
                                       description: 'TCPSocket specifies an action
@@ -1679,15 +1679,15 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
                                             be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                   type: object
                                 preStop:
@@ -1749,8 +1749,8 @@ spec:
                                                 description: The header field value
                                                 type: string
                                             required:
-                                            - name
-                                            - value
+                                              - name
+                                              - value
                                             type: object
                                           type: array
                                         path:
@@ -1759,8 +1759,8 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Name or number of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
@@ -1771,7 +1771,7 @@ spec:
                                             to the host. Defaults to HTTP.
                                           type: string
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                     tcpSocket:
                                       description: 'TCPSocket specifies an action
@@ -1785,15 +1785,15 @@ spec:
                                           type: string
                                         port:
                                           anyOf:
-                                          - type: integer
-                                          - type: string
+                                            - type: integer
+                                            - type: string
                                           description: Number or name of the port
                                             to access on the container. Number must
                                             be in the range 1 to 65535. Name must
                                             be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
-                                      - port
+                                        - port
                                       type: object
                                   type: object
                               type: object
@@ -1849,8 +1849,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -1858,8 +1858,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -1869,7 +1869,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -1901,14 +1901,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -1964,12 +1964,12 @@ spec:
                                       or SCTP. Defaults to "TCP".
                                     type: string
                                 required:
-                                - containerPort
+                                  - containerPort
                                 type: object
                               type: array
                               x-kubernetes-list-map-keys:
-                              - containerPort
-                              - protocol
+                                - containerPort
+                                - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
                               description: 'Periodic probe of container service readiness.
@@ -2023,8 +2023,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -2032,8 +2032,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -2043,7 +2043,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -2075,14 +2075,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -2098,8 +2098,8 @@ spec:
                                 limits:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Limits describes the maximum amount
@@ -2108,8 +2108,8 @@ spec:
                                 requests:
                                   additionalProperties:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   description: 'Requests describes the minimum amount
@@ -2318,8 +2318,8 @@ spec:
                                             description: The header field value
                                             type: string
                                         required:
-                                        - name
-                                        - value
+                                          - name
+                                          - value
                                         type: object
                                       type: array
                                     path:
@@ -2327,8 +2327,8 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Name or number of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
@@ -2338,7 +2338,7 @@ spec:
                                         the host. Defaults to HTTP.
                                       type: string
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 initialDelaySeconds:
                                   description: 'Number of seconds after the container
@@ -2370,14 +2370,14 @@ spec:
                                       type: string
                                     port:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Number or name of the port to access
                                         on the container. Number must be in the range
                                         1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
-                                  - port
+                                    - port
                                   type: object
                                 timeoutSeconds:
                                   description: 'Number of seconds after which the
@@ -2449,8 +2449,8 @@ spec:
                                       in the pod
                                     type: string
                                 required:
-                                - devicePath
-                                - name
+                                  - devicePath
+                                  - name
                                 type: object
                               type: array
                             volumeMounts:
@@ -2494,8 +2494,8 @@ spec:
                                       are mutually exclusive.
                                     type: string
                                 required:
-                                - mountPath
-                                - name
+                                  - mountPath
+                                  - name
                                 type: object
                               type: array
                             workingDir:
@@ -2505,7 +2505,7 @@ spec:
                                 be updated.
                               type: string
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
                       labels:
@@ -2572,7 +2572,7 @@ spec:
                                     in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
-                              - volumeID
+                                - volumeID
                               type: object
                             azureDisk:
                               description: AzureDisk represents an Azure Data Disk
@@ -2607,8 +2607,8 @@ spec:
                                     here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
-                              - diskName
-                              - diskURI
+                                - diskName
+                                - diskURI
                               type: object
                             azureFile:
                               description: AzureFile represents an Azure File Service
@@ -2626,8 +2626,8 @@ spec:
                                   description: Share Name
                                   type: string
                               required:
-                              - secretName
-                              - shareName
+                                - secretName
+                                - shareName
                               type: object
                             cephfs:
                               description: CephFS represents a Ceph FS mount on the
@@ -2670,7 +2670,7 @@ spec:
                                     default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
-                              - monitors
+                                - monitors
                               type: object
                             cinder:
                               description: 'Cinder represents a cinder volume attached
@@ -2704,7 +2704,7 @@ spec:
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
-                              - volumeID
+                                - volumeID
                               type: object
                             configMap:
                               description: ConfigMap represents a configMap that should
@@ -2756,8 +2756,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                    - key
-                                    - path
+                                      - key
+                                      - path
                                     type: object
                                   type: array
                                 name:
@@ -2816,7 +2816,7 @@ spec:
                                     values.
                                   type: object
                               required:
-                              - driver
+                                - driver
                               type: object
                             downwardAPI:
                               description: DownwardAPI represents downward API about
@@ -2855,7 +2855,7 @@ spec:
                                               in the specified API version.
                                             type: string
                                         required:
-                                        - fieldPath
+                                          - fieldPath
                                         type: object
                                       mode:
                                         description: 'Optional: mode bits to use on
@@ -2886,8 +2886,8 @@ spec:
                                             type: string
                                           divisor:
                                             anyOf:
-                                            - type: integer
-                                            - type: string
+                                              - type: integer
+                                              - type: string
                                             description: Specifies the output format
                                               of the exposed resources, defaults to
                                               "1"
@@ -2897,10 +2897,10 @@ spec:
                                             description: 'Required: resource to select'
                                             type: string
                                         required:
-                                        - resource
+                                          - resource
                                         type: object
                                     required:
-                                    - path
+                                      - path
                                     type: object
                                   type: array
                               type: object
@@ -2916,8 +2916,8 @@ spec:
                                   type: string
                                 sizeLimit:
                                   anyOf:
-                                  - type: integer
-                                  - type: string
+                                    - type: integer
+                                    - type: string
                                   description: 'Total amount of local storage required
                                     for this EmptyDir volume. The size limit is also
                                     applicable for memory medium. The maximum usage
@@ -3007,7 +3007,7 @@ spec:
                                       type: string
                                   type: object
                               required:
-                              - driver
+                                - driver
                               type: object
                             flocker:
                               description: Flocker represents a Flocker volume attached
@@ -3058,7 +3058,7 @@ spec:
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
-                              - pdName
+                                - pdName
                               type: object
                             gitRepo:
                               description: 'GitRepo represents a git repository at
@@ -3083,7 +3083,7 @@ spec:
                                   description: Commit hash for the specified revision.
                                   type: string
                               required:
-                              - repository
+                                - repository
                               type: object
                             glusterfs:
                               description: 'Glusterfs represents a Glusterfs mount
@@ -3104,8 +3104,8 @@ spec:
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
-                              - endpoints
-                              - path
+                                - endpoints
+                                - path
                               type: object
                             hostPath:
                               description: 'HostPath represents a pre-existing file
@@ -3128,7 +3128,7 @@ spec:
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
-                              - path
+                                - path
                               type: object
                             iscsi:
                               description: 'ISCSI represents an ISCSI Disk resource
@@ -3198,9 +3198,9 @@ spec:
                                     than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
-                              - iqn
-                              - lun
-                              - targetPortal
+                                - iqn
+                                - lun
+                                - targetPortal
                               type: object
                             name:
                               description: 'Volume''s name. Must be a DNS_LABEL and
@@ -3224,8 +3224,8 @@ spec:
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
-                              - path
-                              - server
+                                - path
+                                - server
                               type: object
                             persistentVolumeClaim:
                               description: 'PersistentVolumeClaimVolumeSource represents
@@ -3242,7 +3242,7 @@ spec:
                                     VolumeMounts. Default false.
                                   type: boolean
                               required:
-                              - claimName
+                                - claimName
                               type: object
                             photonPersistentDisk:
                               description: PhotonPersistentDisk represents a PhotonController
@@ -3260,7 +3260,7 @@ spec:
                                     persistent disk
                                   type: string
                               required:
-                              - pdID
+                                - pdID
                               type: object
                             portworxVolume:
                               description: PortworxVolume represents a portworx volume
@@ -3281,7 +3281,7 @@ spec:
                                     volume
                                   type: string
                               required:
-                              - volumeID
+                                - volumeID
                               type: object
                             projected:
                               description: Items for all in one resources secrets,
@@ -3348,8 +3348,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           name:
@@ -3392,7 +3392,7 @@ spec:
                                                         API version.
                                                       type: string
                                                   required:
-                                                  - fieldPath
+                                                    - fieldPath
                                                   type: object
                                                 mode:
                                                   description: 'Optional: mode bits
@@ -3430,8 +3430,8 @@ spec:
                                                       type: string
                                                     divisor:
                                                       anyOf:
-                                                      - type: integer
-                                                      - type: string
+                                                        - type: integer
+                                                        - type: string
                                                       description: Specifies the output
                                                         format of the exposed resources,
                                                         defaults to "1"
@@ -3442,10 +3442,10 @@ spec:
                                                         to select'
                                                       type: string
                                                   required:
-                                                  - resource
+                                                    - resource
                                                   type: object
                                               required:
-                                              - path
+                                                - path
                                               type: object
                                             type: array
                                         type: object
@@ -3495,8 +3495,8 @@ spec:
                                                     '..'.
                                                   type: string
                                               required:
-                                              - key
-                                              - path
+                                                - key
+                                                - path
                                               type: object
                                             type: array
                                           name:
@@ -3543,12 +3543,12 @@ spec:
                                               the token into.
                                             type: string
                                         required:
-                                        - path
+                                          - path
                                         type: object
                                     type: object
                                   type: array
                               required:
-                              - sources
+                                - sources
                               type: object
                             quobyte:
                               description: Quobyte represents a Quobyte mount on the
@@ -3584,8 +3584,8 @@ spec:
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
-                              - registry
-                              - volume
+                                - registry
+                                - volume
                               type: object
                             rbd:
                               description: 'RBD represents a Rados Block Device mount
@@ -3641,8 +3641,8 @@ spec:
                                     More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
-                              - image
-                              - monitors
+                                - image
+                                - monitors
                               type: object
                             scaleIO:
                               description: ScaleIO represents a ScaleIO persistent
@@ -3702,9 +3702,9 @@ spec:
                                     this volume source.
                                   type: string
                               required:
-                              - gateway
-                              - secretRef
-                              - system
+                                - gateway
+                                - secretRef
+                                - system
                               type: object
                             secret:
                               description: 'Secret represents a secret that should
@@ -3756,8 +3756,8 @@ spec:
                                           May not start with the string '..'.
                                         type: string
                                     required:
-                                    - key
-                                    - path
+                                      - key
+                                      - path
                                     type: object
                                   type: array
                                 optional:
@@ -3835,29 +3835,29 @@ spec:
                                     vmdk
                                   type: string
                               required:
-                              - volumePath
+                                - volumePath
                               type: object
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
                     type: object
                 required:
-                - componentMetadata
-                - name
-                - podAdditions
+                  - componentMetadata
+                  - name
+                  - podAdditions
                 type: object
               type: array
             ready:
               description: Whether the component has finished processing its spec
               type: boolean
           required:
-          - componentDescriptions
-          - ready
+            - componentDescriptions
+            - ready
           type: object
       type: object
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
@@ -667,6 +667,7 @@ spec:
                               type: string
                           required:
                             - containerPort
+                            - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1743,6 +1744,7 @@ spec:
                               type: string
                           required:
                             - containerPort
+                            - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:

--- a/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
@@ -46,8 +46,8 @@ spec:
                       format: int64
                       type: integer
                   required:
-                  - name
-                  - port
+                    - name
+                    - port
                   type: object
                 type: array
               description: Machines to endpoints map
@@ -69,10 +69,10 @@ spec:
               description: WorkspaceId for the workspace being routed
               type: string
           required:
-          - endpoints
-          - podSelector
-          - routingSuffix
-          - workspaceId
+            - endpoints
+            - podSelector
+            - routingSuffix
+            - workspaceId
           type: object
         status:
           description: WorkspaceRoutingStatus defines the observed state of WorkspaceRouting
@@ -93,9 +93,9 @@ spec:
                       description: Public URL of the exposed endpoint
                       type: string
                   required:
-                  - attributes
-                  - name
-                  - url
+                    - attributes
+                    - name
+                    - url
                   type: object
                 type: array
               description: Machine name to exposed endpoint map
@@ -185,7 +185,7 @@ spec:
                                         its key must be defined
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
@@ -202,7 +202,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                  - fieldPath
+                                    - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
@@ -217,8 +217,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -227,7 +227,7 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                  - resource
+                                    - resource
                                   type: object
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
@@ -248,11 +248,11 @@ spec:
                                         key must be defined
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                               type: object
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
                       envFrom:
@@ -362,8 +362,8 @@ spec:
                                           description: The header field value
                                           type: string
                                       required:
-                                      - name
-                                      - value
+                                        - name
+                                        - value
                                       type: object
                                     type: array
                                   path:
@@ -371,8 +371,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
@@ -382,7 +382,7 @@ spec:
                                       host. Defaults to HTTP.
                                     type: string
                                 required:
-                                - port
+                                  - port
                                 type: object
                               tcpSocket:
                                 description: 'TCPSocket specifies an action involving
@@ -395,14 +395,14 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
-                                - port
+                                  - port
                                 type: object
                             type: object
                           preStop:
@@ -460,8 +460,8 @@ spec:
                                           description: The header field value
                                           type: string
                                       required:
-                                      - name
-                                      - value
+                                        - name
+                                        - value
                                       type: object
                                     type: array
                                   path:
@@ -469,8 +469,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
@@ -480,7 +480,7 @@ spec:
                                       host. Defaults to HTTP.
                                     type: string
                                 required:
-                                - port
+                                  - port
                                 type: object
                               tcpSocket:
                                 description: 'TCPSocket specifies an action involving
@@ -493,14 +493,14 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
-                                - port
+                                  - port
                                 type: object
                             type: object
                         type: object
@@ -554,8 +554,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -563,8 +563,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -574,7 +574,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -605,14 +605,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -666,12 +666,12 @@ spec:
                                 SCTP. Defaults to "TCP".
                               type: string
                           required:
-                          - containerPort
+                            - containerPort
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
+                          - containerPort
+                          - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
@@ -723,8 +723,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -732,8 +732,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -743,7 +743,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -774,14 +774,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -797,8 +797,8 @@ spec:
                           limits:
                             additionalProperties:
                               anyOf:
-                              - type: integer
-                              - type: string
+                                - type: integer
+                                - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute
@@ -807,8 +807,8 @@ spec:
                           requests:
                             additionalProperties:
                               anyOf:
-                              - type: integer
-                              - type: string
+                                - type: integer
+                                - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of
@@ -1007,8 +1007,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -1016,8 +1016,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -1027,7 +1027,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -1058,14 +1058,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -1132,8 +1132,8 @@ spec:
                                 in the pod
                               type: string
                           required:
-                          - devicePath
-                          - name
+                            - devicePath
+                            - name
                           type: object
                         type: array
                       volumeMounts:
@@ -1174,8 +1174,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                          - mountPath
-                          - name
+                            - mountPath
+                            - name
                           type: object
                         type: array
                       workingDir:
@@ -1184,7 +1184,7 @@ spec:
                           be configured in the container image. Cannot be updated.
                         type: string
                     required:
-                    - name
+                      - name
                     type: object
                   type: array
                 initContainers:
@@ -1261,7 +1261,7 @@ spec:
                                         its key must be defined
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                                 fieldRef:
                                   description: 'Selects a field of the pod: supports
@@ -1278,7 +1278,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                  - fieldPath
+                                    - fieldPath
                                   type: object
                                 resourceFieldRef:
                                   description: 'Selects a resource of the container:
@@ -1293,8 +1293,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -1303,7 +1303,7 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                  - resource
+                                    - resource
                                   type: object
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's
@@ -1324,11 +1324,11 @@ spec:
                                         key must be defined
                                       type: boolean
                                   required:
-                                  - key
+                                    - key
                                   type: object
                               type: object
                           required:
-                          - name
+                            - name
                           type: object
                         type: array
                       envFrom:
@@ -1438,8 +1438,8 @@ spec:
                                           description: The header field value
                                           type: string
                                       required:
-                                      - name
-                                      - value
+                                        - name
+                                        - value
                                       type: object
                                     type: array
                                   path:
@@ -1447,8 +1447,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
@@ -1458,7 +1458,7 @@ spec:
                                       host. Defaults to HTTP.
                                     type: string
                                 required:
-                                - port
+                                  - port
                                 type: object
                               tcpSocket:
                                 description: 'TCPSocket specifies an action involving
@@ -1471,14 +1471,14 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
-                                - port
+                                  - port
                                 type: object
                             type: object
                           preStop:
@@ -1536,8 +1536,8 @@ spec:
                                           description: The header field value
                                           type: string
                                       required:
-                                      - name
-                                      - value
+                                        - name
+                                        - value
                                       type: object
                                     type: array
                                   path:
@@ -1545,8 +1545,8 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
@@ -1556,7 +1556,7 @@ spec:
                                       host. Defaults to HTTP.
                                     type: string
                                 required:
-                                - port
+                                  - port
                                 type: object
                               tcpSocket:
                                 description: 'TCPSocket specifies an action involving
@@ -1569,14 +1569,14 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
-                                - port
+                                  - port
                                 type: object
                             type: object
                         type: object
@@ -1630,8 +1630,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -1639,8 +1639,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -1650,7 +1650,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -1681,14 +1681,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -1742,12 +1742,12 @@ spec:
                                 SCTP. Defaults to "TCP".
                               type: string
                           required:
-                          - containerPort
+                            - containerPort
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
+                          - containerPort
+                          - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
@@ -1799,8 +1799,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -1808,8 +1808,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -1819,7 +1819,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -1850,14 +1850,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -1873,8 +1873,8 @@ spec:
                           limits:
                             additionalProperties:
                               anyOf:
-                              - type: integer
-                              - type: string
+                                - type: integer
+                                - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute
@@ -1883,8 +1883,8 @@ spec:
                           requests:
                             additionalProperties:
                               anyOf:
-                              - type: integer
-                              - type: string
+                                - type: integer
+                                - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of
@@ -2083,8 +2083,8 @@ spec:
                                       description: The header field value
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                               path:
@@ -2092,8 +2092,8 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
@@ -2103,7 +2103,7 @@ spec:
                                   Defaults to HTTP.
                                 type: string
                             required:
-                            - port
+                              - port
                             type: object
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has
@@ -2134,14 +2134,14 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
-                                - type: string
+                                  - type: integer
+                                  - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
-                            - port
+                              - port
                             type: object
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe
@@ -2208,8 +2208,8 @@ spec:
                                 in the pod
                               type: string
                           required:
-                          - devicePath
-                          - name
+                            - devicePath
+                            - name
                           type: object
                         type: array
                       volumeMounts:
@@ -2250,8 +2250,8 @@ spec:
                                 are mutually exclusive.
                               type: string
                           required:
-                          - mountPath
-                          - name
+                            - mountPath
+                            - name
                           type: object
                         type: array
                       workingDir:
@@ -2260,7 +2260,7 @@ spec:
                           be configured in the container image. Cannot be updated.
                         type: string
                     required:
-                    - name
+                      - name
                     type: object
                   type: array
                 labels:
@@ -2324,7 +2324,7 @@ spec:
                               in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                             type: string
                         required:
-                        - volumeID
+                          - volumeID
                         type: object
                       azureDisk:
                         description: AzureDisk represents an Azure Data Disk mount
@@ -2356,8 +2356,8 @@ spec:
                               here will force the ReadOnly setting in VolumeMounts.
                             type: boolean
                         required:
-                        - diskName
-                        - diskURI
+                          - diskName
+                          - diskURI
                         type: object
                       azureFile:
                         description: AzureFile represents an Azure File Service mount
@@ -2375,8 +2375,8 @@ spec:
                             description: Share Name
                             type: string
                         required:
-                        - secretName
-                        - shareName
+                          - secretName
+                          - shareName
                         type: object
                       cephfs:
                         description: CephFS represents a Ceph FS mount on the host
@@ -2418,7 +2418,7 @@ spec:
                               is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                             type: string
                         required:
-                        - monitors
+                          - monitors
                         type: object
                       cinder:
                         description: 'Cinder represents a cinder volume attached and
@@ -2450,7 +2450,7 @@ spec:
                               cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                             type: string
                         required:
-                        - volumeID
+                          - volumeID
                         type: object
                       configMap:
                         description: ConfigMap represents a configMap that should
@@ -2497,8 +2497,8 @@ spec:
                                     the string '..'.
                                   type: string
                               required:
-                              - key
-                              - path
+                                - key
+                                - path
                               type: object
                             type: array
                           name:
@@ -2553,7 +2553,7 @@ spec:
                               documentation for supported values.
                             type: object
                         required:
-                        - driver
+                          - driver
                         type: object
                       downwardAPI:
                         description: DownwardAPI represents downward API about the
@@ -2588,7 +2588,7 @@ spec:
                                         the specified API version.
                                       type: string
                                   required:
-                                  - fieldPath
+                                    - fieldPath
                                   type: object
                                 mode:
                                   description: 'Optional: mode bits to use on this
@@ -2618,8 +2618,8 @@ spec:
                                       type: string
                                     divisor:
                                       anyOf:
-                                      - type: integer
-                                      - type: string
+                                        - type: integer
+                                        - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
@@ -2628,10 +2628,10 @@ spec:
                                       description: 'Required: resource to select'
                                       type: string
                                   required:
-                                  - resource
+                                    - resource
                                   type: object
                               required:
-                              - path
+                                - path
                               type: object
                             type: array
                         type: object
@@ -2647,8 +2647,8 @@ spec:
                             type: string
                           sizeLimit:
                             anyOf:
-                            - type: integer
-                            - type: string
+                              - type: integer
+                              - type: string
                             description: 'Total amount of local storage required for
                               this EmptyDir volume. The size limit is also applicable
                               for memory medium. The maximum usage on memory medium
@@ -2730,7 +2730,7 @@ spec:
                                 type: string
                             type: object
                         required:
-                        - driver
+                          - driver
                         type: object
                       flocker:
                         description: Flocker represents a Flocker volume attached
@@ -2779,7 +2779,7 @@ spec:
                               in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                             type: boolean
                         required:
-                        - pdName
+                          - pdName
                         type: object
                       gitRepo:
                         description: 'GitRepo represents a git repository at a particular
@@ -2802,7 +2802,7 @@ spec:
                             description: Commit hash for the specified revision.
                             type: string
                         required:
-                        - repository
+                          - repository
                         type: object
                       glusterfs:
                         description: 'Glusterfs represents a Glusterfs mount on the
@@ -2822,8 +2822,8 @@ spec:
                               false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                             type: boolean
                         required:
-                        - endpoints
-                        - path
+                          - endpoints
+                          - path
                         type: object
                       hostPath:
                         description: 'HostPath represents a pre-existing file or directory
@@ -2844,7 +2844,7 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                             type: string
                         required:
-                        - path
+                          - path
                         type: object
                       iscsi:
                         description: 'ISCSI represents an ISCSI Disk resource that
@@ -2910,9 +2910,9 @@ spec:
                               (typically TCP ports 860 and 3260).
                             type: string
                         required:
-                        - iqn
-                        - lun
-                        - targetPortal
+                          - iqn
+                          - lun
+                          - targetPortal
                         type: object
                       name:
                         description: 'Volume''s name. Must be a DNS_LABEL and unique
@@ -2936,8 +2936,8 @@ spec:
                               the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                             type: string
                         required:
-                        - path
-                        - server
+                          - path
+                          - server
                         type: object
                       persistentVolumeClaim:
                         description: 'PersistentVolumeClaimVolumeSource represents
@@ -2954,7 +2954,7 @@ spec:
                               Default false.
                             type: boolean
                         required:
-                        - claimName
+                          - claimName
                         type: object
                       photonPersistentDisk:
                         description: PhotonPersistentDisk represents a PhotonController
@@ -2970,7 +2970,7 @@ spec:
                               disk
                             type: string
                         required:
-                        - pdID
+                          - pdID
                         type: object
                       portworxVolume:
                         description: PortworxVolume represents a portworx volume attached
@@ -2990,7 +2990,7 @@ spec:
                             description: VolumeID uniquely identifies a Portworx volume
                             type: string
                         required:
-                        - volumeID
+                          - volumeID
                         type: object
                       projected:
                         description: Items for all in one resources secrets, configmaps,
@@ -3053,8 +3053,8 @@ spec:
                                               string '..'.
                                             type: string
                                         required:
-                                        - key
-                                        - path
+                                          - key
+                                          - path
                                         type: object
                                       type: array
                                     name:
@@ -3095,7 +3095,7 @@ spec:
                                                   select in the specified API version.
                                                 type: string
                                             required:
-                                            - fieldPath
+                                              - fieldPath
                                             type: object
                                           mode:
                                             description: 'Optional: mode bits to use
@@ -3129,8 +3129,8 @@ spec:
                                                 type: string
                                               divisor:
                                                 anyOf:
-                                                - type: integer
-                                                - type: string
+                                                  - type: integer
+                                                  - type: string
                                                 description: Specifies the output
                                                   format of the exposed resources,
                                                   defaults to "1"
@@ -3141,10 +3141,10 @@ spec:
                                                   select'
                                                 type: string
                                             required:
-                                            - resource
+                                              - resource
                                             type: object
                                         required:
-                                        - path
+                                          - path
                                         type: object
                                       type: array
                                   type: object
@@ -3190,8 +3190,8 @@ spec:
                                               string '..'.
                                             type: string
                                         required:
-                                        - key
-                                        - path
+                                          - key
+                                          - path
                                         type: object
                                       type: array
                                     name:
@@ -3235,12 +3235,12 @@ spec:
                                         into.
                                       type: string
                                   required:
-                                  - path
+                                    - path
                                   type: object
                               type: object
                             type: array
                         required:
-                        - sources
+                          - sources
                         type: object
                       quobyte:
                         description: Quobyte represents a Quobyte mount on the host
@@ -3275,8 +3275,8 @@ spec:
                               created Quobyte volume by name.
                             type: string
                         required:
-                        - registry
-                        - volume
+                          - registry
+                          - volume
                         type: object
                       rbd:
                         description: 'RBD represents a Rados Block Device mount on
@@ -3328,8 +3328,8 @@ spec:
                               info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                             type: string
                         required:
-                        - image
-                        - monitors
+                          - image
+                          - monitors
                         type: object
                       scaleIO:
                         description: ScaleIO represents a ScaleIO persistent volume
@@ -3384,9 +3384,9 @@ spec:
                               ScaleIO system that is associated with this volume source.
                             type: string
                         required:
-                        - gateway
-                        - secretRef
-                        - system
+                          - gateway
+                          - secretRef
+                          - system
                         type: object
                       secret:
                         description: 'Secret represents a secret that should populate
@@ -3433,8 +3433,8 @@ spec:
                                     the string '..'.
                                   type: string
                               required:
-                              - key
-                              - path
+                                - key
+                                - path
                               type: object
                             type: array
                           optional:
@@ -3507,10 +3507,10 @@ spec:
                             description: Path that identifies vSphere volume vmdk
                             type: string
                         required:
-                        - volumePath
+                          - volumePath
                         type: object
                     required:
-                    - name
+                      - name
                     type: object
                   type: array
               type: object
@@ -3518,6 +3518,6 @@ spec:
       type: object
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/patch/patch_crds.sh
+++ b/patch/patch_crds.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# This script is required to make automatically generated CRDs compatible with
+# Kubernetes >1.18
+#
+# Patching is done in-place. Note that the formatting output by yq is slightly
+# different than the one output by operator-sdk generate commands: list items
+# are indented one level further:
+#     list:            list:
+#     - item1    -->     - item1
+#     - item2            - item2
+#
+
+set -e
+
+COMPONENTS_CRD_PATH="deploy/crds/workspace.che.eclipse.org_components_crd.yaml"
+ROUTINGS_CRD_PATH="deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml"
+
+# CRD path from root to status field, in jq filter format
+STATUS_PATH='.spec.validation.openAPIV3Schema.properties["status"]'
+# CRD path podAdditions to containerPorts required field, in jq filter format
+# Note this path takes one jq arg: "CONTAINERS_FIELD" can be used to specify
+# "containers" or "initContainers", as both have containerPorts that must be patched.
+PODADDITIONS_PATH='.properties["podAdditions"].properties[$CONTAINERS_FIELD].items.properties["ports"].items.required'
+
+# Full jq path to container ports required field in components CRD.
+COMPONENTS_SPEC_PATH="${STATUS_PATH}"'.properties["componentDescriptions"].items'"${PODADDITIONS_PATH}"
+# Full jq path to container ports required field in workspaceroutings CRD.
+ROUTINGS_SPEC_PATH="${STATUS_PATH}${PODADDITIONS_PATH}"
+
+# Update components CRD using yq; no-op if already patched.
+# Args:
+#  $1 - podAdditions field to update ("containers" or "initContainers")
+function update_components_crd() {
+  field="$1"
+  local yq_check_script="${COMPONENTS_SPEC_PATH}"' | index("protocol")'
+  local yq_patch_script="${COMPONENTS_SPEC_PATH}"' |= . + ["protocol"]'
+  already_patched=$(yq -r "$yq_check_script" "$COMPONENTS_CRD_PATH" --arg "CONTAINERS_FIELD" "$field")
+  if [[ "$already_patched" == "null" ]]; then
+    yq -Y -i "$yq_patch_script" "$COMPONENTS_CRD_PATH" --arg "CONTAINERS_FIELD" "$field"
+    echo "Updated CRD $COMPONENTS_CRD_PATH"
+  else
+    echo "Updating CRD $COMPONENTS_CRD_PATH not necessary"
+  fi
+}
+
+# Update workspaceroutings CRD using yq; no-op if already patched.
+# Args:
+#  $1 - podAdditions field to update ("containers" or "initContainers")
+function update_routings_crd() {
+  field="$1"
+  local yq_check_script="${ROUTINGS_SPEC_PATH}"' | index("protocol")'
+  local yq_patch_script="${ROUTINGS_SPEC_PATH}"' |= . + ["protocol"]'
+  already_patched=$(yq -r "$yq_check_script" "$ROUTINGS_CRD_PATH" --arg "CONTAINERS_FIELD" "$field")
+  if [[ "$already_patched" == "null" ]]; then
+    yq -Y -i "$yq_patch_script" "$ROUTINGS_CRD_PATH" --arg "CONTAINERS_FIELD" "$field"
+    echo "Updated CRD ${ROUTINGS_CRD_PATH}"
+  else
+    echo "Updating CRD ${ROUTINGS_CRD_PATH} not necessary"
+  fi
+}
+
+if ! command -v yq 2> /dev/null; then
+  echo "Error patching crds: yq is required"
+  exit 1
+fi
+
+update_components_crd "containers"
+update_components_crd "initContainers"
+update_routings_crd "containers"
+update_routings_crd "initContainers"


### PR DESCRIPTION
### What does this PR do?
Updates CRDs to workaround issue https://github.com/eclipse/che/issues/16791

Adds a script that does the required patch, depending on `yq`. This script is executed during `make generate`.

This PR is broken into three commits
- 76059d3 is a no-op formatting change -- I ran the existing CRDs through `yq` to make the formatting consistent and avoid spurious changes (in short, `yq` formats yaml differently than operator-sdk
- 121ef2b adds script `patch/patch_crds.sh` which will add `protocol` to the list of required fields in containerPorts
- b618f6b regenerates CRDs and runs the script (`make generate`)

### What issues does this PR fix or reference?
Workaround for https://github.com/eclipse/che/issues/16791

### Is it tested? How?
Tested applying CRDs to minikube with kubernetes 1.18. Could not test full deployment/workspace start as my minikube network is borked for some reason.