### PR TITLE
Add Command Line Terminal cheEditor into internal Plugin Registry

### DIFF
--- a/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+publisher: che-incubator
+name: command-line-terminal
+version: 4.5.0
+type: Che Editor
+displayName: Command Line Terminal
+title: Command Line Terminal
+description: Command Line Terminal provides the ability to start a terminal inside the OpenShift Console.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-05-13"
+category: Other
+spec:
+  endpoints:
+   -  name: command-line-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        path: /static/
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: command-line-terminal
+     image: "quay.io/eclipse/che-machine-exec:nightly"
+#    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
+#    image: "quay.io/che-incubator/command-line-terminal:4.5.0"
+     ports:
+       - exposedPort: 4444

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+publisher: che-incubator
+name: command-line-terminal
+version: nightly
+type: Che Editor
+displayName: Command Line Terminal
+title: Command Line Terminal
+description: Command Line Terminal provides the ability to start a terminal inside the OpenShift Console.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-05-13"
+category: Other
+spec:
+  endpoints:
+   -  name: command-line-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        path: /static/
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+   - name: command-line-terminal
+     image: "quay.io/eclipse/che-machine-exec:nightly"
+#    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
+#    image: "quay.io/che-incubator/command-line-terminal:nightly"
+     ports:
+       - exposedPort: 4444

--- a/samples/command-line-terminal.yaml
+++ b/samples/command-line-terminal.yaml
@@ -1,0 +1,31 @@
+# It's just an example of workspace configuration OpenShift Console creates
+# when user requests terminal
+apiVersion: workspace.che.eclipse.org/v1alpha1
+kind: Workspace
+metadata:
+  name: command-line-terminal
+  annotations:
+    # it's important to make workspace immutable to make sure nobody with right access
+    # won't set custom editor to steal creator's token
+    org.eclipse.che.workspace/immutable: "true"
+  labels:
+    # it's a label OpenShift console uses a flag to mark terminal's workspaces
+    console.openshift.io/cloudshell: "true"
+spec:
+  started: true
+  devfile:
+    apiVersion: 1.0.0
+    metadata:
+      name: command-line-terminal
+    components:
+      - alias: command-line-terminal
+        type: cheEditor
+        id: che-incubator/command-line-terminal/4.5.0
+      - type: dockerimage
+        memoryLimit: 256Mi
+        alias: dev
+        image: 'registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1'
+        args: ["tail", "-f", "/dev/null"]
+        env:
+          - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
+            name: PS1


### PR DESCRIPTION
### What does this PR do?
This PR adds Command Line Terminal cheEditor into internal Plugin Registry, it's needed since currently, OpenShift Console depends on the nightly CloudShell https://github.com/openshift/console/blob/cd751e4badfd55d79df916ca8bca0b6126c446b3/frontend/packages/console-app/src/components/cloud-shell/cloud-shell-utils.ts#L70
and since code-freeze OpenShift 4.5 is coming it's critical to put some long-term supported version.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
not yet
