### PR TITLE
Add cluster routingclass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ webhook:
 ifeq ($(WEBHOOK_ENABLED),true)
 ifeq ($(TOOL),kubectl)
 	./deploy/webhook-server-certs/deploy-webhook-server-certs.sh kubectl
-	kubectl patch deployment che-workspace-controller -p "$$(cat ./deploy/k8s/controller-tls.yaml)"
+	kubectl patch deployment -n $(NAMESPACE) che-workspace-controller -p "$$(cat ./deploy/k8s/controller-tls.yaml)"
 endif
 else
 	@echo "Webhooks disabled, skipping certificate generation"

--- a/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_components_crd.yaml
@@ -2535,6 +2535,48 @@ spec:
                           it might be used for e.g. OpenShift oauth with SA as auth
                           client
                         type: object
+                      volumeMounts:
+                        description: VolumeMounts to add to all containers in a workspace
+                          deployment
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves
+                                similarly to SubPath but environment variable references
+                                $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root). SubPathExpr and SubPath
+                                are mutually exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
                       volumes:
                         description: Volumes to add to workspace deployment
                         items:

--- a/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaceroutings_crd.yaml
@@ -2288,6 +2288,47 @@ spec:
                   description: Annotations for the workspace service account, it might
                     be used for e.g. OpenShift oauth with SA as auth client
                   type: object
+                volumeMounts:
+                  description: VolumeMounts to add to all containers in a workspace
+                    deployment
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly
+                          to SubPath but environment variable references $(VAR_NAME)
+                          are expanded using the container's environment. Defaults
+                          to "" (volume's root). SubPathExpr and SubPath are mutually
+                          exclusive.
+                        type: string
+                    required:
+                      - mountPath
+                      - name
+                    type: object
+                  type: array
                 volumes:
                   description: Volumes to add to workspace deployment
                   items:

--- a/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
@@ -221,7 +221,7 @@ spec:
         status:
           description: WorkspaceStatus defines the observed state of Workspace
           properties:
-            condition:
+            conditions:
               description: Conditions represent the latest available observations
                 of an object's state
               items:

--- a/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
@@ -28,7 +28,8 @@ spec:
      #    image: "quay.io/che-incubator/command-line-terminal:4.5.0"
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+               "--use-tls"]
      ports:
        - exposedPort: 4444
      env:

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -28,7 +28,8 @@ spec:
      #    image: "quay.io/che-incubator/command-line-terminal:nightly"
      command: ["/go/bin/che-machine-exec",
                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+               "--use-tls"]
      ports:
        - exposedPort: 4444
       env:

--- a/pkg/apis/workspace/v1alpha1/common.go
+++ b/pkg/apis/workspace/v1alpha1/common.go
@@ -41,6 +41,11 @@ type PodAdditions struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Volumes []v1.Volume `json:"volumes,omitempty"`
+	// VolumeMounts to add to all containers in a workspace deployment
+	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
 	// ImagePullSecrets to add to workspace deployment
 	// +optional
 	// +patchMergeKey=name

--- a/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
@@ -34,10 +34,11 @@ type WorkspaceRoutingSpec struct {
 type WorkspaceRoutingClass string
 
 const (
-	WorkspaceRoutingDefault        WorkspaceRoutingClass = "basic"
-	WorkspaceRoutingOpenShiftOauth WorkspaceRoutingClass = "openshift-oauth"
-	WorkspaceRoutingCluster        WorkspaceRoutingClass = "cluster"
-	WorkspaceRoutingClusterTLS     WorkspaceRoutingClass = "cluster-tls"
+	WorkspaceRoutingDefault           WorkspaceRoutingClass = "basic"
+	WorkspaceRoutingOpenShiftOauth    WorkspaceRoutingClass = "openshift-oauth"
+	WorkspaceRoutingCluster           WorkspaceRoutingClass = "cluster"
+	WorkspaceRoutingClusterTLS        WorkspaceRoutingClass = "cluster-tls"
+	WorkspaceRoutingOpenShiftTerminal WorkspaceRoutingClass = "openshift-terminal"
 )
 
 // WorkspaceRoutingStatus defines the observed state of WorkspaceRouting

--- a/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
@@ -37,6 +37,7 @@ const (
 	WorkspaceRoutingDefault        WorkspaceRoutingClass = "basic"
 	WorkspaceRoutingOpenShiftOauth WorkspaceRoutingClass = "openshift-oauth"
 	WorkspaceRoutingCluster        WorkspaceRoutingClass = "cluster"
+	WorkspaceRoutingClusterTLS     WorkspaceRoutingClass = "cluster-tls"
 )
 
 // WorkspaceRoutingStatus defines the observed state of WorkspaceRouting

--- a/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspacerouting_types.go
@@ -36,6 +36,7 @@ type WorkspaceRoutingClass string
 const (
 	WorkspaceRoutingDefault        WorkspaceRoutingClass = "basic"
 	WorkspaceRoutingOpenShiftOauth WorkspaceRoutingClass = "openshift-oauth"
+	WorkspaceRoutingCluster        WorkspaceRoutingClass = "cluster"
 )
 
 // WorkspaceRoutingStatus defines the observed state of WorkspaceRouting

--- a/pkg/apis/workspace/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/workspace/v1alpha1/zz_generated.deepcopy.go
@@ -597,6 +597,13 @@ func (in *PodAdditions) DeepCopyInto(out *PodAdditions) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.PullSecrets != nil {
 		in, out := &in.PullSecrets, &out.PullSecrets
 		*out = make([]v1.LocalObjectReference, len(*in))

--- a/pkg/common/naming.go
+++ b/pkg/common/naming.go
@@ -62,3 +62,7 @@ func OAuthProxySecretName(workspaceId string) string {
 func DeploymentName(workspaceId string) string {
 	return workspaceId
 }
+
+func ServingCertVolumeName(serviceName string) string {
+	return fmt.Sprintf("workspace-serving-cert-%s", serviceName)
+}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -33,12 +33,6 @@ const (
 	SidecarDefaultMemoryLimit = "128M"
 	PVCStorageSize            = "1Gi"
 
-	// RuntimeAdditionalInfo is a key of workspaceStatus.AdditionalInfo where runtime info is stored
-	RuntimeAdditionalInfo = "org.eclipse.che.workspace/runtime"
-
-	// RuntimeAdditionalInfo is a key of workspaceStatus.AdditionalInfo info where component statuses info is stored
-	ComponentStatusesAdditionalInfo = "org.eclipse.che.workspace/componentstatuses"
-
 	// WorkspaceIDLabel is label key to store workspace identifier
 	WorkspaceIDLabel = "che.workspace_id"
 
@@ -51,9 +45,15 @@ const (
 	// CheOriginalNameLabel is label key to original name
 	CheOriginalNameLabel = "che.original_name"
 
+	// WorkspaceCreatorLabel is the annotation key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "org.eclipse.che.workspace/creator"
 
+	// WorkspaceImmutableAnnotation marks a workspace as 'immutable' if 'true'
 	WorkspaceImmutableAnnotation = "org.eclipse.che.workspace/immutable"
+
+	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
+	// as opposed to a service created to support the workspace itself.
+	WorkspaceDiscoverableServiceAnnotation = "org.eclipse.che.workspace/discoverable-service"
 )
 
 // Constants for che-rest-apis

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -45,7 +45,7 @@ const (
 	// CheOriginalNameLabel is label key to original name
 	CheOriginalNameLabel = "che.original_name"
 
-	// WorkspaceCreatorLabel is the annotation key for storing the UID of the user who created the workspace
+	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "org.eclipse.che.workspace/creator"
 
 	// WorkspaceImmutableAnnotation marks a workspace as 'immutable' if 'true'

--- a/pkg/controller/workspace/provision/routing.go
+++ b/pkg/controller/workspace/provision/routing.go
@@ -64,7 +64,7 @@ func SyncRoutingToCluster(
 		}
 	}
 
-	if (specRouting.Spec.RoutingClass != clusterRouting.Spec.RoutingClass) {
+	if specRouting.Spec.RoutingClass != clusterRouting.Spec.RoutingClass {
 		err := clusterAPI.Client.Delete(context.TODO(), clusterRouting)
 		return RoutingProvisioningStatus{
 			ProvisioningStatus: ProvisioningStatus{Requeue: true, Err: err},

--- a/pkg/controller/workspacerouting/solvers/basic_solver.go
+++ b/pkg/controller/workspacerouting/solvers/basic_solver.go
@@ -37,3 +37,9 @@ func (s *BasicSolver) GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec, workspa
 		Routes:    routes,
 	}
 }
+
+func (s *BasicSolver) GetExposedEndpoints(
+	endpoints map[string]v1alpha1.EndpointList,
+	routingObj RoutingObjects) (exposedEndpoints map[string]v1alpha1.ExposedEndpointList, ready bool, err error) {
+	return getExposedEndpoints(endpoints, routingObj)
+}

--- a/pkg/controller/workspacerouting/solvers/cluster_solver.go
+++ b/pkg/controller/workspacerouting/solvers/cluster_solver.go
@@ -1,0 +1,65 @@
+package solvers
+
+import (
+	"fmt"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ClusterSolver struct{}
+
+var _ RoutingSolver = (*ClusterSolver)(nil)
+
+func (s *ClusterSolver) GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec, workspaceMeta WorkspaceMetadata) RoutingObjects {
+	services := getServicesForEndpoints(spec.Endpoints, workspaceMeta)
+
+	return RoutingObjects{
+		Services: services,
+	}
+}
+
+func (s *ClusterSolver) GetExposedEndpoints(
+	endpoints map[string]v1alpha1.EndpointList,
+	routingObj RoutingObjects) (exposedEndpoints map[string]v1alpha1.ExposedEndpointList, ready bool, err error) {
+
+	exposedEndpoints = map[string]v1alpha1.ExposedEndpointList{}
+
+	for machineName, machineEndpoints := range endpoints {
+		for _, endpoint := range machineEndpoints {
+			if endpoint.Attributes[v1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE] != "true" {
+				continue
+			}
+			url, err := resolveServiceHostnameForEndpoint(endpoint, routingObj.Services)
+			if err != nil {
+				return nil, false, err
+			}
+			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], v1alpha1.ExposedEndpoint{
+				Name:       endpoint.Name,
+				Url:        url,
+				Attributes: endpoint.Attributes,
+			})
+		}
+	}
+
+	return exposedEndpoints, true, nil
+}
+
+func resolveServiceHostnameForEndpoint(endpoint v1alpha1.Endpoint, services []corev1.Service) (string, error) {
+	for _, service := range services {
+		if service.Annotations[config.WorkspaceDiscoverableServiceAnnotation] == "true" {
+			continue
+		}
+		for _, servicePort := range service.Spec.Ports {
+			if int64(servicePort.Port) == endpoint.Port {
+				return getHostnameFromService(service, servicePort.Port), nil
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find service for endpoint %s", endpoint.Name)
+}
+
+func getHostnameFromService(service corev1.Service, port int32) string {
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, port)
+}

--- a/pkg/controller/workspacerouting/solvers/common.go
+++ b/pkg/controller/workspacerouting/solvers/common.go
@@ -51,6 +51,9 @@ func getDiscoverableServicesForEndpoints(endpoints map[string]v1alpha1.EndpointL
 						Labels: map[string]string{
 							config.WorkspaceIDLabel: meta.WorkspaceId,
 						},
+						Annotations: map[string]string{
+							config.WorkspaceDiscoverableServiceAnnotation: "true",
+						},
 					},
 					Spec: corev1.ServiceSpec{
 						Ports:    []corev1.ServicePort{servicePort},

--- a/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
+++ b/pkg/controller/workspacerouting/solvers/openshift_oauth_solver.go
@@ -84,6 +84,12 @@ func (s *OpenShiftOAuthSolver) GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec
 	}
 }
 
+func (s *OpenShiftOAuthSolver) GetExposedEndpoints(
+	endpoints map[string]v1alpha1.EndpointList,
+	routingObj RoutingObjects) (exposedEndpoints map[string]v1alpha1.ExposedEndpointList, ready bool, err error) {
+	return getExposedEndpoints(endpoints, routingObj)
+}
+
 func (s *OpenShiftOAuthSolver) getProxyRoutes(
 	endpoints map[string]v1alpha1.EndpointList,
 	workspaceMeta WorkspaceMetadata,

--- a/pkg/controller/workspacerouting/solvers/solver.go
+++ b/pkg/controller/workspacerouting/solvers/solver.go
@@ -30,4 +30,5 @@ type RoutingObjects struct {
 
 type RoutingSolver interface {
 	GetSpecObjects(spec v1alpha1.WorkspaceRoutingSpec, workspaceMeta WorkspaceMetadata) RoutingObjects
+	GetExposedEndpoints(endpoints map[string]v1alpha1.EndpointList, routingObj RoutingObjects) (exposedEndpoints map[string]v1alpha1.ExposedEndpointList, ready bool, err error)
 }

--- a/pkg/controller/workspacerouting/workspacerouting_controller.go
+++ b/pkg/controller/workspacerouting/workspacerouting_controller.go
@@ -296,7 +296,7 @@ func getSolverForRoutingClass(routingClass workspacev1alpha1.WorkspaceRoutingCla
 		return &solvers.OpenShiftOAuthSolver{}, nil
 	case workspacev1alpha1.WorkspaceRoutingCluster:
 		return &solvers.ClusterSolver{}, nil
-	case workspacev1alpha1.WorkspaceRoutingClusterTLS:
+	case workspacev1alpha1.WorkspaceRoutingClusterTLS, workspacev1alpha1.WorkspaceRoutingOpenShiftTerminal:
 		if !config.ControllerCfg.IsOpenShift() {
 			return nil, fmt.Errorf("routing class %s only supported on OpenShift", routingClass)
 		}

--- a/pkg/controller/workspacerouting/workspacerouting_controller.go
+++ b/pkg/controller/workspacerouting/workspacerouting_controller.go
@@ -296,6 +296,11 @@ func getSolverForRoutingClass(routingClass workspacev1alpha1.WorkspaceRoutingCla
 		return &solvers.OpenShiftOAuthSolver{}, nil
 	case workspacev1alpha1.WorkspaceRoutingCluster:
 		return &solvers.ClusterSolver{}, nil
+	case workspacev1alpha1.WorkspaceRoutingClusterTLS:
+		if !config.ControllerCfg.IsOpenShift() {
+			return nil, fmt.Errorf("routing class %s only supported on OpenShift", routingClass)
+		}
+		return &solvers.ClusterSolver{TLS: true}, nil
 	default:
 		return nil, fmt.Errorf("routing class %s not supported", routingClass)
 	}

--- a/samples/command-line-terminal.yaml
+++ b/samples/command-line-terminal.yaml
@@ -13,7 +13,7 @@ metadata:
     console.openshift.io/cloudshell: "true"
 spec:
   started: true
-  routingClass: cluster-tls
+  routingClass: openshift-terminal
   devfile:
     apiVersion: 1.0.0
     metadata:

--- a/samples/command-line-terminal.yaml
+++ b/samples/command-line-terminal.yaml
@@ -13,6 +13,7 @@ metadata:
     console.openshift.io/cloudshell: "true"
 spec:
   started: true
+  routingClass: cluster-tls
   devfile:
     apiVersion: 1.0.0
     metadata:


### PR DESCRIPTION
### What does this PR do?
Add another routing class to our workspace spec: `cluster`. With `routingClass: cluster`, the controller will not create routes/ingresses and will instead use the created service's DNS names for endpoints. 

I haven't tested how this works with various network policies yet, but presumably it won't work if network policies do not allow cross-namespace communication.

### What issues does this PR fix or reference?
Resolves https://github.com/eclipse/che/issues/16863

### Is it tested? How?
Tested on `crc` and `minikube`. 

To test:
```
# ...other env vars as usual
export DEFAULT_ROUTING=cluster
make deploy
oc apply -f ./samples/cloud-shell.yaml
```
then `oc rsh` or `kubectl exec -it` into another pod on the cluster (e.g. plugin registry) and try to curl `${workspace.ideUrl}/static/`.