### PR TITLE
Only propagate creator annotation if present

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -24,8 +24,6 @@ const (
 	DefaultPluginsVolumeName = "plugins"
 	PluginsMountPath         = "/plugins"
 
-	CheOriginalName = "workspace"
-
 	AuthEnabled = "false"
 
 	ServiceAccount = "che-workspace"
@@ -41,9 +39,6 @@ const (
 
 	// WorkspaceNameLabel is label key to store workspace identifier
 	WorkspaceNameLabel = "che.workspace_name"
-
-	// CheOriginalNameLabel is label key to original name
-	CheOriginalNameLabel = "che.original_name"
 
 	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
 	WorkspaceCreatorLabel = "org.eclipse.che.workspace/creator"

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -200,8 +200,8 @@ func getSpecDeployment(
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, getPersistentVolumeClaim())
 	}
 
-	workspaceCreator := workspace.Annotations[config.WorkspaceCreatorLabel]
-	if workspaceCreator != "" {
+	workspaceCreator, present := workspace.Labels[config.WorkspaceCreatorLabel]
+	if present {
 		deployment.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
 		deployment.Spec.Template.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
 	}

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -159,9 +159,8 @@ func getSpecDeployment(
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					config.CheOriginalNameLabel: config.CheOriginalName,
-					config.WorkspaceIDLabel:     workspace.Status.WorkspaceId,
-					config.WorkspaceNameLabel:   workspace.Name,
+					config.WorkspaceIDLabel:   workspace.Status.WorkspaceId,
+					config.WorkspaceNameLabel: workspace.Name,
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
@@ -172,9 +171,8 @@ func getSpecDeployment(
 					Name:      workspace.Status.WorkspaceId,
 					Namespace: workspace.Namespace,
 					Labels: map[string]string{
-						config.CheOriginalNameLabel: config.CheOriginalName,
-						config.WorkspaceIDLabel:     workspace.Status.WorkspaceId,
-						config.WorkspaceNameLabel:   workspace.Name,
+						config.WorkspaceIDLabel:   workspace.Status.WorkspaceId,
+						config.WorkspaceNameLabel: workspace.Name,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -152,8 +152,7 @@ func getSpecDeployment(
 			Name:      common.DeploymentName(workspace.Status.WorkspaceId),
 			Namespace: workspace.Namespace,
 			Labels: map[string]string{
-				config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
-				config.WorkspaceCreatorLabel: creator,
+				config.WorkspaceIDLabel: workspace.Status.WorkspaceId,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -173,10 +172,9 @@ func getSpecDeployment(
 					Name:      workspace.Status.WorkspaceId,
 					Namespace: workspace.Namespace,
 					Labels: map[string]string{
-						config.CheOriginalNameLabel:  config.CheOriginalName,
-						config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
-						config.WorkspaceNameLabel:    workspace.Name,
-						config.WorkspaceCreatorLabel: creator,
+						config.CheOriginalNameLabel: config.CheOriginalName,
+						config.WorkspaceIDLabel:     workspace.Status.WorkspaceId,
+						config.WorkspaceNameLabel:   workspace.Name,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -200,6 +198,12 @@ func getSpecDeployment(
 	if IsPVCRequired(components) {
 		deployment.Spec.Template.Spec.InitContainers = append(deployment.Spec.Template.Spec.InitContainers, precreateSubpathsInitContainer(workspace.Status.WorkspaceId))
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, getPersistentVolumeClaim())
+	}
+
+	workspaceCreator := workspace.Annotations[config.WorkspaceCreatorLabel]
+	if workspaceCreator != "" {
+		deployment.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
+		deployment.Spec.Template.Labels[config.WorkspaceCreatorLabel] = workspaceCreator
 	}
 
 	err = controllerutil.SetControllerReference(workspace, deployment, scheme)


### PR DESCRIPTION
### What does this PR do?
Only propagate creator annotation to workspace deployment if it is nonempty, to avoid applying an empty annotation to deployments when running with webhooks disabled.

### What issues does this PR fix or reference?
Fix for first part of https://github.com/eclipse/che/issues/16627

### Is it tested? How?
Tested on crc with and without webhooks enabled. With webhooks, behavior is unmodified; without no creator annotation is created on deployments.