### PR TITLE
Move creator UID info to labels instead of annotations

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -51,7 +51,7 @@ const (
 	// CheOriginalNameLabel is label key to original name
 	CheOriginalNameLabel = "che.original_name"
 
-	WorkspaceCreatorAnnotation = "org.eclipse.che.workspace/creator"
+	WorkspaceCreatorLabel = "org.eclipse.che.workspace/creator"
 
 	WorkspaceImmutableAnnotation = "org.eclipse.che.workspace/immutable"
 )

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -149,10 +149,8 @@ func getSpecDeployment(
 			Name:      common.DeploymentName(workspace.Status.WorkspaceId),
 			Namespace: workspace.Namespace,
 			Labels: map[string]string{
-				config.WorkspaceIDLabel: workspace.Status.WorkspaceId,
-			},
-			Annotations: map[string]string{
-				config.WorkspaceCreatorAnnotation: workspace.Annotations[config.WorkspaceCreatorAnnotation],
+				config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
+				config.WorkspaceCreatorLabel: workspace.Labels[config.WorkspaceCreatorLabel],
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -172,12 +170,10 @@ func getSpecDeployment(
 					Name:      workspace.Status.WorkspaceId,
 					Namespace: workspace.Namespace,
 					Labels: map[string]string{
-						config.CheOriginalNameLabel: config.CheOriginalName,
-						config.WorkspaceIDLabel:     workspace.Status.WorkspaceId,
-						config.WorkspaceNameLabel:   workspace.Name,
-					},
-					Annotations: map[string]string{
-						config.WorkspaceCreatorAnnotation: workspace.Annotations[config.WorkspaceCreatorAnnotation],
+						config.CheOriginalNameLabel:  config.CheOriginalName,
+						config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
+						config.WorkspaceNameLabel:    workspace.Name,
+						config.WorkspaceCreatorLabel: workspace.Labels[config.WorkspaceCreatorLabel],
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/webhook/workspace/handler/exec.go
+++ b/pkg/webhook/workspace/handler/exec.go
@@ -39,7 +39,7 @@ func (h *WebhookHandler) ValidateExecOnConnect(ctx context.Context, req admissio
 		return admission.Allowed("It's not workspace related pod")
 	}
 
-	creator, ok := p.Annotations[config.WorkspaceCreatorAnnotation]
+	creator, ok := p.Labels[config.WorkspaceCreatorLabel]
 	if !ok {
 		return admission.Denied("The workspace info is missing in the workspace-related pod")
 	}

--- a/pkg/webhook/workspace/mutate.go
+++ b/pkg/webhook/workspace/mutate.go
@@ -21,8 +21,8 @@ import (
 )
 
 // ResourcesMutator checks that every:
-// - workspace has creator annotation specified and it's not modified
-// - workspace-related deployment, pod has unmodified workspace-id label and creator annotation
+// - workspace has creator label specified and it's not modified
+// - workspace-related deployment, pod has unmodified workspace-id label and creator label
 type ResourcesMutator struct {
 	*handler.WebhookHandler
 }


### PR DESCRIPTION
### What does this PR do?
Move creator UID info to labels instead of annotations.
It's needed to make easier find the right workspace for OpenShift Console.
But if we don't take into account OpenShift Console, labels make more sense for storing such info,
possibly chectl later will reuse the same label.

UID seems to be compatible with label format.

### What issues does this PR fix or reference?
No issue created. I'd spend more time on the issue that PR creation ;)

### Is it tested? How?
I've tested command-line-terminal with kubeadmin and developer
![Screenshot_20200515_124807](https://user-images.githubusercontent.com/5887312/82037627-125ed400-96ab-11ea-99aa-82536946bebf.png)
![Screenshot_20200515_124826](https://user-images.githubusercontent.com/5887312/82037635-14c12e00-96ab-11ea-9542-facce6383232.png)
![Screenshot_20200515_124845](https://user-images.githubusercontent.com/5887312/82037639-168af180-96ab-11ea-895b-63b659d82773.png)

:warning: Dear reviewers, please checkout locally and give a look if I did not miss any place.
I'll do another round of checking if there is nothing missing before merging.
