### PR TITLE
Make terminal configure USE_BEARER_TOKEN and authenticated user

### DIFF
--- a/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
@@ -25,6 +25,10 @@ spec:
    - name: command-line-terminal
      image: "quay.io/eclipse/che-machine-exec:nightly"
 #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
-#    image: "quay.io/che-incubator/command-line-terminal:4.5.0"
+     #    image: "quay.io/che-incubator/command-line-terminal:4.5.0"
+     command: ["/go/bin/che-machine-exec", "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)"]
      ports:
        - exposedPort: 4444
+     env:
+       - name: USE_BEARER_TOKEN
+         value: true

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -24,7 +24,11 @@ spec:
   containers:
    - name: command-line-terminal
      image: "quay.io/eclipse/che-machine-exec:nightly"
-#    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
-#    image: "quay.io/che-incubator/command-line-terminal:nightly"
+     #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
+     #    image: "quay.io/che-incubator/command-line-terminal:nightly"
+     command: ["/go/bin/che-machine-exec", "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)"]
      ports:
        - exposedPort: 4444
+      env:
+        - name: USE_BEARER_TOKEN
+          value: true

--- a/pkg/controller/workspace/env/common_env_vars.go
+++ b/pkg/controller/workspace/env/common_env_vars.go
@@ -17,7 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func CommonEnvironmentVariables(workspaceName, workspaceId, namespace string) []corev1.EnvVar {
+func CommonEnvironmentVariables(workspaceName, workspaceId, namespace, creator string) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name: "CHE_MACHINE_TOKEN",
@@ -57,6 +57,10 @@ func CommonEnvironmentVariables(workspaceName, workspaceId, namespace string) []
 		{
 			Name:  "USE_BEARER_TOKEN",
 			Value: config.ControllerCfg.GetWebhooksEnabled(),
+		},
+		{
+			Name:  "CHE_WORKSPACE_CREATOR",
+			Value: creator,
 		},
 	}
 }

--- a/pkg/controller/workspace/provision/deployment.go
+++ b/pkg/controller/workspace/provision/deployment.go
@@ -136,7 +136,8 @@ func getSpecDeployment(
 		return nil, err
 	}
 
-	commonEnv := env.CommonEnvironmentVariables(workspace.Name, workspace.Status.WorkspaceId, workspace.Namespace)
+	creator := workspace.Labels[config.WorkspaceCreatorLabel]
+	commonEnv := env.CommonEnvironmentVariables(workspace.Name, workspace.Status.WorkspaceId, workspace.Namespace, creator)
 	for idx := range podAdditions.Containers {
 		podAdditions.Containers[idx].Env = append(podAdditions.Containers[idx].Env, commonEnv...)
 	}
@@ -150,7 +151,7 @@ func getSpecDeployment(
 			Namespace: workspace.Namespace,
 			Labels: map[string]string{
 				config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
-				config.WorkspaceCreatorLabel: workspace.Labels[config.WorkspaceCreatorLabel],
+				config.WorkspaceCreatorLabel: creator,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -173,7 +174,7 @@ func getSpecDeployment(
 						config.CheOriginalNameLabel:  config.CheOriginalName,
 						config.WorkspaceIDLabel:      workspace.Status.WorkspaceId,
 						config.WorkspaceNameLabel:    workspace.Name,
-						config.WorkspaceCreatorLabel: workspace.Labels[config.WorkspaceCreatorLabel],
+						config.WorkspaceCreatorLabel: creator,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/workspace/provision/rbac.go
+++ b/pkg/controller/workspace/provision/rbac.go
@@ -54,6 +54,11 @@ func generateRBAC(namespace string) []runtime.Object {
 					APIGroups: []string{"apps", "extensions"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					Resources: []string{"workspaces"},
+					APIGroups: []string{"workspace.che.eclipse.org"},
+					Verbs:     []string{"patch"},
+				},
 			},
 		},
 		&rbacv1.RoleBinding{


### PR DESCRIPTION
### What does this PR do?
This PR make terminal configures USE_BEARER_TOKEN and authenticated user

Also, this PR grants workspace SA to patch workspace, it's needed for che-machine-exec to be able to stop itself after period of inactivity. Since it's a tiny change I won't move it to a separate PR.

### What issues does this PR fix or reference?
It fixes eclipse/che#16489
It's needed for https://github.com/eclipse/che-machine-exec/pull/104

### Is it tested? How?

Create a workspace with the following config
```yaml
# It's just an example of workspace configuration OpenShift Console creates
# when user requests terminal
apiVersion: workspace.che.eclipse.org/v1alpha1
kind: Workspace
metadata:
  name: command-line-terminal
spec:
  started: true
  routingClass: openshift-oauth
  devfile:
    apiVersion: 1.0.0
    metadata:
      name: command-line-terminal
    components:
      - alias: command-line-terminal
        type: cheEditor
        reference: https://gist.githubusercontent.com/sleshchenko/0128432ed8b8c07ac1aecf626446e2b2/raw/21b2a5a094f260f8600a26a8a45362201e769a8e/command-line-pr-test.yaml
      - type: dockerimage
        memoryLimit: 256Mi
        alias: dev
        image: 'registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1'
        args: ["tail", "-f", "/dev/null"]
        env:
          - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
            name: PS1
```
check that the only creator is able to open a terminal.

No-creator is not able even establish WebSocket connection.

I was not able to check command line + openshift console since
kube:admin is not able open terminal anymore
developer is not able to find his workspaces yet =(