### PR TITLE
Check servers health before setting status to running

### DIFF
--- a/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
@@ -18,7 +18,6 @@ spec:
       attributes:
         protocol: http
         type: ide
-        path: /static/
         discoverable: false
         secure: true
         cookiesAuthEnabled: true

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -18,7 +18,6 @@ spec:
       attributes:
         protocol: http
         type: ide
-        path: /static/
         discoverable: false
         secure: true
         cookiesAuthEnabled: true


### PR DESCRIPTION
### What does this PR do?
Adds polling to `${ideUrl}/healthz` and doesn't set `Running` phase for workspace until endpoint is responding. 

Expects a 2xx response, but will proceed on a 404 for compatibility. 

### What issues does this PR fix or reference?
503 errors in OpenShift Terminal

### Is it tested? How?
Depends on https://github.com/eclipse/che-machine-exec/pull/105 ideally. Image is built and available at `docker.io/amisevsk/che-machine-exec:dev`, which you can use in the internal registry for testing.

Tested on `crc` with updated image and with default image that doesn't have `/healthz` endpoint.

On my local `crc`, I typically see 2-3 seconds of `503` errors before getting a `200`
