### PR TITLE
Rename ide url

### DIFF
--- a/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
+++ b/deploy/crds/workspace.che.eclipse.org_workspaces_crd.yaml
@@ -12,7 +12,7 @@ spec:
     description: The current workspace startup phase
     name: Phase
     type: string
-  - JSONPath: .status.ideUrl
+  - JSONPath: .status.mainIdeUrl
     description: Url endpoint for accessing workspace
     name: URL
     type: string
@@ -253,14 +253,14 @@ spec:
                 - type
                 type: object
               type: array
-            ideUrl:
+            mainIdeUrl:
               type: string
             phase:
               type: string
             workspaceId:
               type: string
           required:
-          - ideUrl
+          - mainIdeUrl
           - workspaceId
           type: object
       type: object

--- a/pkg/apis/workspace/v1alpha1/workspace_types.go
+++ b/pkg/apis/workspace/v1alpha1/workspace_types.go
@@ -34,7 +34,7 @@ type WorkspaceSpec struct {
 type WorkspaceStatus struct {
 	WorkspaceId string         `json:"workspaceId"`
 	Phase       WorkspacePhase `json:"phase,omitempty"`
-	IdeUrl      string         `json:"ideUrl"`
+	MainIdeUrl  string         `json:"mainIdeUrl"`
 	// Conditions represent the latest available observations of an object's state
 	Condition []WorkspaceCondition `json:"condition,omitempty"`
 }
@@ -83,7 +83,7 @@ const (
 // +kubebuilder:resource:path=workspaces,scope=Namespaced
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
-// +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"
+// +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.mainIdeUrl",description="Url endpoint for accessing workspace"
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/workspace/status.go
+++ b/pkg/controller/workspace/status.go
@@ -79,10 +79,10 @@ func (r *ReconcileWorkspace) updateWorkspaceStatus(workspace *v1alpha1.Workspace
 func SyncWorkspaceIdeURL(workspace *v1alpha1.Workspace, exposedEndpoints map[string]v1alpha1.ExposedEndpointList, clusterAPI provision.ClusterAPI) (ok bool, err error) {
 	ideUrl := getIdeUrl(exposedEndpoints)
 
-	if workspace.Status.IdeUrl == ideUrl {
+	if workspace.Status.MainIdeUrl == ideUrl {
 		return true, nil
 	}
-	workspace.Status.IdeUrl = ideUrl
+	workspace.Status.MainIdeUrl = ideUrl
 	err = clusterAPI.Client.Status().Update(context.TODO(), workspace)
 	return false, err
 }


### PR DESCRIPTION
### What does this PR do?
Rename `workspace.status.ideUrl` to `workspace.status.mainIdeUrl` to support compatibility with [devfile 2.0 spec](https://github.com/devfile/kubernetes-api/blob/06293a5b9f8aef0a82e20c3085739d04766c5295/pkg/apis/workspaces/v1alpha1/devworkspace_types.go#L21). 

### What issues does this PR fix or reference?
OpenShift Terminal should be compatible with both current CRD and devfile 2.0 if possible. Console backend proxy depends on ideUrl for proxying requests

### Is it tested? How?
Tested deploying updated CRDs on `crc`, URL field in `oc get workspace` is set correctly. 