### PR TITLE
Provision default dockerimage for command-line-terminal.

### DIFF
--- a/pkg/config/cmd_terminal.go
+++ b/pkg/config/cmd_terminal.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// property name for value with yaml for default dockerimage component
+	// that should be provisioned if devfile DOES have che-incubator/command-line-terminal cheEditor
+	// and DOES NOT have any dockerimage component
+	defaultTerminalDockerimageProperty = "che.workspace.default_dockerimage.che-incubator.command-line-terminal"
+)
+
+var (
+	defaultTerminalDockerimage = &v1alpha1.ComponentSpec{
+		Type:        "dockerimage",
+		MemoryLimit: "256Mi",
+		Alias:       "dev",
+		Image:       "registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1",
+		Args:        []string{"tail", "-f", "/dev/null"},
+		Env: []v1alpha1.Env{
+			{
+				Name:  "PS1",
+				Value: "\\[\\e[34m\\]>\\[\\e[m\\]\\[\\e[33m\\]>\\[\\e[m\\]",
+			},
+		},
+	}
+)
+
+func (wc *ControllerConfig) GetDefaultTerminalDockerimage() (*v1alpha1.ComponentSpec, error) {
+	defaultDockerimageYaml := wc.GetProperty(defaultTerminalDockerimageProperty)
+	if defaultDockerimageYaml == nil {
+		return defaultTerminalDockerimage.DeepCopy(), nil
+	}
+
+	var dockerimage v1alpha1.ComponentSpec
+	if err := yaml.Unmarshal([]byte(*defaultDockerimageYaml), &dockerimage); err != nil {
+		return nil, fmt.Errorf(
+			"%s is configure with invalid dockerimage component. Error: %s", defaultTerminalDockerimageProperty, err)
+	}
+
+	return &dockerimage, nil
+}

--- a/pkg/controller/component/cmd_terminal/cmd_terminal.go
+++ b/pkg/controller/component/cmd_terminal/cmd_terminal.go
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package cmd_terminal
+
+import (
+	"strings"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+)
+
+const (
+	CommandLineTerminalPublisherName = "che-incubator/command-line-terminal/"
+)
+
+func ContainsCmdTerminalComponent(plugins []v1alpha1.ComponentSpec) bool {
+	for _, p := range plugins {
+		if IsCommandLineTerminalPlugin(p) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsCommandLineTerminalPlugin(p v1alpha1.ComponentSpec) bool {
+	if strings.HasPrefix(p.Id, CommandLineTerminalPublisherName) {
+		return true
+	}
+	return false
+}

--- a/pkg/controller/component/component_controller.go
+++ b/pkg/controller/component/component_controller.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -96,7 +96,7 @@ func (r *ReconcileComponent) Reconcile(request reconcile.Request) (reconcile.Res
 	instance := &workspacev1alpha1.Component{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
@@ -154,7 +154,7 @@ func (r *ReconcileComponent) reconcileConfigMap(instance *workspacev1alpha1.Comp
 	}
 	err = r.client.Get(context.TODO(), namespacedName, clusterConfigMap)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8sErrors.IsNotFound(err) {
 			log.Info("Creating broker ConfigMap")
 			err := r.client.Create(context.TODO(), cm)
 			return false, err

--- a/samples/command-line-terminal.yaml
+++ b/samples/command-line-terminal.yaml
@@ -21,11 +21,3 @@ spec:
       - alias: command-line-terminal
         type: cheEditor
         id: che-incubator/command-line-terminal/4.5.0
-      - type: dockerimage
-        memoryLimit: 256Mi
-        alias: dev
-        image: 'registry.redhat.io/codeready-workspaces/plugin-openshift-rhel8:2.1'
-        args: ["tail", "-f", "/dev/null"]
-        env:
-          - value: '\[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]'
-            name: PS1


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is making controller provision default dockerimage for command-line-terminal.

As a second commit, it also makes endpoint health check compatible with OpenShift OAuth Routing:
1. Do not check TLS.
2. Consider 401 or 403 as successful response from endpoint.

### What issues does this PR fix or reference?
N/A

### Known limitations
1. Default dockerimage won't be applied if command line terminal is configured with reference.
I tried to provision default dockerimage in `component_controller.go` where all plugins info is fetched but and dockerimage is successfully provisioned in workspace pod but no component is created.
BTW This issue could be handled separately and this PR should contains enough to get rid of dockerimage component configuration on OpenShift Console.

### Is it tested? How?
1. Create a command-line terminal workspace without dockerimage:
```bash
cat << EOF | oc apply -f - 
# It's just an example of workspace configuration OpenShift Console creates
# when user requests terminal
apiVersion: workspace.che.eclipse.org/v1alpha1
kind: Workspace
metadata:
  name: command-line-terminal
spec:
  started: true
  devfile:
    apiVersion: 1.0.0
    metadata:
      name: command-line-terminal
    components:
      - alias: command-line-terminal
        type: cheEditor
        id: che-incubator/command-line-terminal/4.5.0
EOF
```
2. Check that dockerimage component is created and workspace pod contains default openshift-plugin container.
3. Update default dockerimage used by controller
```
oc patch configmap che-workspace-controller --patch '{ "data": { "che.workspace.default_dockerimage.che-incubator.command-line-terminal": "alias: dev\nargs:\n- tail\n- -f\n- /dev/null\nenv:\n- name: PS1\n  value: \\[\\e[34m\\]>\\[\\e[m\\]\\[\\e[33m\\]>\\[\\e[m\\]\nimage: quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509\nmemoryLimit: 256Mi\ntype: dockerimage\n" } }' --type=merge
kc rollout restart deployment che-workspace-controller
```
3. Check that workspace is reconciled and dockerimage component is updated along with workspace pod.
4. Provision dockerimage into workspace spec
```bash
cat << EOF | oc apply -f - 
# It's just an example of workspace configuration OpenShift Console creates
# when user requests terminal
apiVersion: workspace.che.eclipse.org/v1alpha1
kind: Workspace
metadata:
  name: command-line-terminal
spec:
  started: true
  devfile:
    apiVersion: 1.0.0
    metadata:
      name: command-line-terminal
    components:
      - alias: command-line-terminal
        type: cheEditor
        id: che-incubator/command-line-terminal/4.5.0
      - type: dockerimage
        memoryLimit: 256Mi
        alias: dev
        image: 'quay.io/eclipse/che-sidecar-openshift-connector:0.1.2-2601509'
        args: ["tail", "-f", "/dev/null"]
        env:
          - value: 'hello'
            name: PS1
EOF
```
5. Verify that new env var came to dockerimage component + workspace pod.
