### PR TITLE
Add stopping by idle timeout for command-line-terminal

### DIFF
--- a/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/4.5.0/meta.yaml
@@ -26,7 +26,9 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
 #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
      #    image: "quay.io/che-incubator/command-line-terminal:4.5.0"
-     command: ["/go/bin/che-machine-exec", "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)"]
+     command: ["/go/bin/che-machine-exec",
+               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
      ports:
        - exposedPort: 4444
      env:

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -26,7 +26,9 @@ spec:
      image: "quay.io/eclipse/che-machine-exec:nightly"
      #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
      #    image: "quay.io/che-incubator/command-line-terminal:nightly"
-     command: ["/go/bin/che-machine-exec", "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)"]
+     command: ["/go/bin/che-machine-exec",
+               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
      ports:
        - exposedPort: 4444
       env:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,10 @@ func (wc *ControllerConfig) Validate() error {
 	return nil
 }
 
+func (wc *ControllerConfig) GetWorkspaceIdleTimeout() string {
+	return wc.GetPropertyOrDefault(workspaceIdleTimeout, defaultWorkspaceIdleTimeout)
+}
+
 func updateConfigMap(client client.Client, meta metav1.Object, obj runtime.Object) {
 	if meta.GetNamespace() != ConfigMapReference.Namespace ||
 		meta.GetName() != ConfigMapReference.Name {

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -39,4 +39,7 @@ const (
 
 	webhooksEnabled        = "che.webhooks.enabled"
 	defaultWebhooksEnabled = "false"
+
+	workspaceIdleTimeout        = "che.workspace.idle_timeout"
+	defaultWorkspaceIdleTimeout = "15m"
 )

--- a/pkg/controller/workspace/env/common_env_vars.go
+++ b/pkg/controller/workspace/env/common_env_vars.go
@@ -62,5 +62,9 @@ func CommonEnvironmentVariables(workspaceName, workspaceId, namespace, creator s
 			Name:  "CHE_WORKSPACE_CREATOR",
 			Value: creator,
 		},
+		{
+			Name:  "CHE_WORKSPACE_IDLE_TIMEOUT",
+			Value: config.ControllerCfg.GetWorkspaceIdleTimeout(),
+		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds stopping by idle timeout for command-line-terminal.

It also fixes starting/stoping immutable workspace on OpenShift 4.5. Previously it failed with error:\
```
workspace 'terminal-0bpuux' is immutable. To make modifications it must be deleted and recreated"
```
I did not investigate changes on OpenShift API side with ManagedFields, just found different and fix an issue. We must get ourselves familiar with that part of object and how it's supposed to be used..

<details>
<summary>Open it if you want to see JSON that webhook server gets</summary>

OldWorkspace
```json
{
  "kind": "Workspace",
  "apiVersion": "workspace.che.eclipse.org/v1alpha1",
  "metadata": {
    "name": "command-line-terminal",
    "namespace": "che-workspace-controller",
    "uid": "3a9903d1-ff48-45ad-8eaf-18af733d3806",
    "resourceVersion": "267365",
    "generation": 1,
    "creationTimestamp": "2020-05-27T07:31:50Z",
    "labels": {
      "console.openshift.io/cloudshell": "true",
      "org.eclipse.che.workspace/creator": ""
    },
    "annotations": {
      "kubectl.kubernetes.io/last-applied-configuration": "...",
      "org.eclipse.che.workspace/immutable": "true"
    }
  },
  "spec": {
    "started": true,
    "devfile": {
      "apiVersion": "1.0.0",
      "metadata": {
        "name": "command-line-terminal"
      },
      "attributes": {},
      "components": [
        {
          "type": "cheEditor",
          "alias": "command-line-terminal",
          "id": "che-incubator/command-line-terminal/4.5.0"
        }
      ]
    }
  },
  "status": {
    "workspaceId": "workspace3a9903d1ff4845ad",
    "phase": "Running",
    "ideUrl": "http://workspace3a9903d1ff4845ad-command-line-terminal-4444.apps.gamore45installer27thmay.devcluster.openshift.com",
    "conditions": [
      {
        "type": "ServiceAccountReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "RoutingReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "Ready",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "ComponentsReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      }
    ]
  }
}
```

newWorkspace
```json
{
  "kind": "Workspace",
  "apiVersion": "workspace.che.eclipse.org/v1alpha1",
  "metadata": {
    "name": "command-line-terminal",
    "namespace": "che-workspace-controller",
    "uid": "3a9903d1-ff48-45ad-8eaf-18af733d3806",
    "resourceVersion": "267365",
    "generation": 1,
    "creationTimestamp": "2020-05-27T07:31:50Z",
    "labels": {
      "console.openshift.io/cloudshell": "true",
      "org.eclipse.che.workspace/creator": ""
    },
    "annotations": {
      "kubectl.kubernetes.io/last-applied-configuration": "....",
      "org.eclipse.che.workspace/immutable": "true"
    },
    "managedFields": [
      {
        "manager": "che-workspace-controller",
        "operation": "Update",
        "apiVersion": "workspace.che.eclipse.org/v1alpha1",
        "time": "2020-05-27T08:05:20Z",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:status": {
            ".": {},
            "f:conditions": {},
            "f:ideUrl": {},
            "f:phase": {},
            "f:workspaceId": {}
          }
        }
      },
      {
        "manager": "kubectl",
        "operation": "Update",
        "apiVersion": "workspace.che.eclipse.org/v1alpha1",
        "time": "2020-05-27T08:05:32Z",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:metadata": {
            "f:annotations": {
              ".": {},
              "f:kubectl.kubernetes.io/last-applied-configuration": {},
              "f:org.eclipse.che.workspace/immutable": {}
            },
            "f:labels": {
              ".": {},
              "f:console.openshift.io/cloudshell": {}
            }
          },
          "f:spec": {
            ".": {},
            "f:devfile": {
              ".": {},
              "f:apiVersion": {},
              "f:components": {},
              "f:metadata": {
                ".": {},
                "f:name": {}
              }
            },
            "f:started": {}
          }
        }
      }
    ]
  },
  "spec": {
    "started": false,
    "devfile": {
      "apiVersion": "1.0.0",
      "metadata": {
        "name": "command-line-terminal"
      },
      "attributes": {},
      "components": [
        {
          "type": "cheEditor",
          "alias": "command-line-terminal",
          "id": "che-incubator/command-line-terminal/4.5.0"
        }
      ]
    }
  },
  "status": {
    "workspaceId": "workspace3a9903d1ff4845ad",
    "phase": "Running",
    "ideUrl": "http://workspace3a9903d1ff4845ad-command-line-terminal-4444.apps.gamore45installer27thmay.devcluster.openshift.com",
    "conditions": [
      {
        "type": "ServiceAccountReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "RoutingReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "Ready",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      },
      {
        "type": "ComponentsReady",
        "status": "True",
        "lastTransitionTime": "2020-05-27T08:05:20Z"
      }
    ]
  }
}
```

</details>

### What issues does this PR fix or reference?
It along with https://github.com/eclipse/che-machine-exec/pull/106 fixes eclipse/che#16683

### Is it tested? How?
1. Configure idle_timeout to some easy to test value, like `che.workspace.idle_timeout: 59s`.
2. Start command line terminal workspace.
3. Watch command line terminal logs.
4. Make sure the workspace is stopped after idle timeout is reached.
![Screenshot_20200526_153602](https://user-images.githubusercontent.com/5887312/82902300-ec1d1c00-9f67-11ea-9771-d6d45019f0ed.png)

I also tested that workspace is not stopped that activity it reported:
![Screenshot_20200527_121041](https://user-images.githubusercontent.com/5887312/83001020-d2391300-a013-11ea-8030-cdabce96beeb.png)
