### PR TITLE
Add dev version of command-line-terminal that doesn't use TLS

### DIFF
--- a/internal-registry/che-incubator/command-line-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal-dev/4.5.0/meta.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+publisher: che-incubator
+name: command-line-terminal
+version: 4.5.0
+type: Che Editor
+displayName: Command Line Terminal
+title: Command Line Terminal
+description: Command Line Terminal provides the ability to start a terminal inside
+  the OpenShift Console.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-05-13"
+category: Other
+spec:
+  endpoints:
+    - name: command-line-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+    - name: command-line-terminal
+      image: "quay.io/eclipse/che-machine-exec:nightly"
+      command: ["/go/bin/che-machine-exec",
+                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+      ports:
+        - exposedPort: 4444
+      env:
+        - name: USE_BEARER_TOKEN
+          value: true

--- a/internal-registry/che-incubator/command-line-terminal-dev/4.5.0/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal-dev/4.5.0/meta.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 publisher: che-incubator
-name: command-line-terminal
+name: command-line-terminal-dev
 version: 4.5.0
 type: Che Editor
-displayName: Command Line Terminal
-title: Command Line Terminal
+displayName: Dev Command Line Terminal
+title: Dev Command Line Terminal
 description: Command Line Terminal provides the ability to start a terminal inside
-  the OpenShift Console.
+  the OpenShift Console. The development version does not run with TLS enabled and
+  is intended for development purposes only.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
-firstPublicationDate: "2020-05-13"
+firstPublicationDate: "2020-06-01"
 category: Other
 spec:
   endpoints:

--- a/internal-registry/che-incubator/command-line-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal-dev/nightly/meta.yaml
@@ -1,0 +1,35 @@
+apiVersion: v2
+publisher: che-incubator
+name: command-line-terminal
+version: nightly
+type: Che Editor
+displayName: Command Line Terminal
+title: Command Line Terminal
+description: Command Line Terminal provides the ability to start a terminal inside
+  the OpenShift Console.
+icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+repository: https://github.com/eclipse/che-machine-exec/
+firstPublicationDate: "2020-05-13"
+category: Other
+spec:
+  endpoints:
+    - name: command-line-terminal
+      public: true
+      targetPort: 4444
+      attributes:
+        protocol: http
+        type: ide
+        discoverable: false
+        secure: true
+        cookiesAuthEnabled: true
+  containers:
+    - name: command-line-terminal
+      image: "quay.io/eclipse/che-machine-exec:nightly"
+      command: ["/go/bin/che-machine-exec",
+                "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+                "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)"]
+      ports:
+        - exposedPort: 4444
+      env:
+        - name: USE_BEARER_TOKEN
+          value: true

--- a/internal-registry/che-incubator/command-line-terminal-dev/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal-dev/nightly/meta.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
 publisher: che-incubator
-name: command-line-terminal
+name: command-line-terminal-dev
 version: nightly
 type: Che Editor
-displayName: Command Line Terminal
-title: Command Line Terminal
+displayName: Dev Command Line Terminal
+title: Dev Command Line Terminal
 description: Command Line Terminal provides the ability to start a terminal inside
-  the OpenShift Console.
+  the OpenShift Console. The development version does not run with TLS enabled and
+  is intended for development purposes only.
 icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
 repository: https://github.com/eclipse/che-machine-exec/
-firstPublicationDate: "2020-05-13"
+firstPublicationDate: "2020-06-01"
 category: Other
 spec:
   endpoints:

--- a/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
+++ b/internal-registry/che-incubator/command-line-terminal/nightly/meta.yaml
@@ -12,26 +12,26 @@ firstPublicationDate: "2020-05-13"
 category: Other
 spec:
   endpoints:
-   -  name: command-line-terminal
-      public: true
-      targetPort: 4444
-      attributes:
-        protocol: http
-        type: ide
-        discoverable: false
-        secure: true
-        cookiesAuthEnabled: true
+  - name: command-line-terminal
+    public: true
+    targetPort: 4444
+    attributes:
+      protocol: http
+      type: ide
+      discoverable: false
+      secure: true
+      cookiesAuthEnabled: true
   containers:
-   - name: command-line-terminal
-     image: "quay.io/eclipse/che-machine-exec:nightly"
-     #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
-     #    image: "quay.io/che-incubator/command-line-terminal:nightly"
-     command: ["/go/bin/che-machine-exec",
-               "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
-               "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
-               "--use-tls"]
-     ports:
-       - exposedPort: 4444
-      env:
-        - name: USE_BEARER_TOKEN
-          value: true
+  - name: command-line-terminal
+    image: "quay.io/eclipse/che-machine-exec:nightly"
+    #    ^ it'll be replaced with new image below after https://github.com/eclipse/che/issues/16942 is fixed
+    #    image: "quay.io/che-incubator/command-line-terminal:nightly"
+    command: ["/go/bin/che-machine-exec",
+              "--authenticated-user-id", "$(CHE_WORKSPACE_CREATOR)",
+              "--idle-timeout", "$(CHE_WORKSPACE_IDLE_TIMEOUT)",
+              "--use-tls"]
+    ports:
+      - exposedPort: 4444
+    env:
+      - name: USE_BEARER_TOKEN
+        value: true

--- a/pkg/controller/component/cmd_terminal/cmd_terminal.go
+++ b/pkg/controller/component/cmd_terminal/cmd_terminal.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	CommandLineTerminalPublisherName = "che-incubator/command-line-terminal/"
+	CommandLineTerminalPublisherName    = "che-incubator/command-line-terminal/"
+	CommandLineTerminalDevPublisherName = "che-incubator/command-line-terminal-dev/"
 )
 
 func ContainsCmdTerminalComponent(plugins []v1alpha1.ComponentSpec) bool {
@@ -32,7 +33,7 @@ func ContainsCmdTerminalComponent(plugins []v1alpha1.ComponentSpec) bool {
 }
 
 func IsCommandLineTerminalPlugin(p v1alpha1.ComponentSpec) bool {
-	if strings.HasPrefix(p.Id, CommandLineTerminalPublisherName) {
+	if strings.HasPrefix(p.Id, CommandLineTerminalPublisherName) || strings.HasPrefix(p.Id, CommandLineTerminalDevPublisherName) {
 		return true
 	}
 	return false

--- a/samples/command-line-terminal-dev.yaml
+++ b/samples/command-line-terminal-dev.yaml
@@ -1,0 +1,24 @@
+# It's just an example of workspace configuration OpenShift Console creates
+# when user requests terminal
+apiVersion: workspace.che.eclipse.org/v1alpha1
+kind: Workspace
+metadata:
+  name: command-line-terminal
+  annotations:
+    # it's important to make workspace immutable to make sure nobody with right access
+    # won't set custom editor to steal creator's token
+    org.eclipse.che.workspace/immutable: "true"
+  labels:
+    # it's a label OpenShift console uses a flag to mark terminal's workspaces
+    console.openshift.io/cloudshell: "true"
+spec:
+  started: true
+  routingClass: basic
+  devfile:
+    apiVersion: 1.0.0
+    metadata:
+      name: command-line-terminal
+    components:
+      - alias: command-line-terminal
+        type: cheEditor
+        id: che-incubator/command-line-terminal-dev/4.5.0


### PR DESCRIPTION
### What does this PR do?
Add plugin `che-incubator/command-line-terminal-dev/[nightly|4.5.0]` to the internal registry. This plugin is identical to the command-line-terminal plugin, except it does not enable TLS in the editor.

### What issues does this PR fix or reference?
The normal command-line-terminal plugin only works if all components are running in the cluster
- `cluster-tls` routing is inaccessible if the controller is running locally
- `basic` routing causes a crashloop since the plugin expects certificates to be mounted.

This also blocks testing openshift-console changes locally, for the same reasons.

### Is it tested? How?
Tested on OpenShift 4.5
