### PR TITLE
Update default config map properties when controller-config isn't cre…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,10 +235,7 @@ func buildDefaultConfigMap(cm *corev1.ConfigMap) {
 	cm.Name = ConfigMapReference.Name
 	cm.Namespace = ConfigMapReference.Namespace
 
-	cm.Data = map[string]string{
-		routingSuffix:              defaultRoutingSuffix,
-		pluginArtifactsBrokerImage: defaultPluginArtifactsBrokerImage,
-	}
+	cm.Data = map[string]string{}
 }
 
 func fillOpenShiftRouteSuffixIfNecessary(nonCachedClient client.Client, configMap *corev1.ConfigMap) error {

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -38,7 +38,7 @@ const (
 	defaultRoutingClass = "basic"
 
 	webhooksEnabled        = "che.webhooks.enabled"
-	defaultWebhooksEnabled = "false"
+	defaultWebhooksEnabled = "true"
 
 	workspaceIdleTimeout        = "che.workspace.idle_timeout"
 	defaultWorkspaceIdleTimeout = "15m"


### PR DESCRIPTION
…ated on cluster

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR updates the default config map properties for when we are deploying the operator with OLM and we cannot deploy the che-workspace-controller configmap.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17042

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested by removing all references to controller-config.yaml in the Makefile and deleting the controller-config yaml file from the repo.

Then deploying the changes with `make deploy` and then creating a cloud shell and see that everything starts correctly