### PR TITLE
Align configuration properties names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ _update_yamls: _set_registry_url
 	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "$(WEBHOOK_ENABLED)"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "$(DEFAULT_ROUTING)"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: $(ROUTING_SUFFIX)|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|che.workspace.sidecar.image_pull_policy: .*|che.workspace.sidecar.image_pull_policy: $(PULL_POLICY)|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|image: .*|image: $(IMG)|g" ./deploy/os/controller.yaml
@@ -80,6 +81,7 @@ _reset_yamls: _set_registry_url
 	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "false"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: 192.168.99.100.nip.io|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|che.workspace.sidecar.image_pull_policy: .*|che.workspace.sidecar.image_pull_policy: Always|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
 	sed -i.bak -e "s|image: $(IMG)|image: quay.io/che-incubator/che-workspace-controller:nightly|g" ./deploy/os/controller.yaml

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 _update_yamls: _set_registry_url
 	sed -i.bak -e "s|plugin.registry.url: .*|plugin.registry.url: http://$(PLUGIN_REGISTRY_HOST)|g" ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "$(WEBHOOK_ENABLED)"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.default_routing_class: .*|che.default_routing_class: "$(DEFAULT_ROUTING)"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "$(DEFAULT_ROUTING)"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: $(ROUTING_SUFFIX)|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)
@@ -78,7 +78,7 @@ endif
 _reset_yamls: _set_registry_url
 	sed -i.bak -e "s|http://$(PLUGIN_REGISTRY_HOST)|http://che-plugin-registry.192.168.99.100.nip.io/v3|g" ./deploy/controller_config.yaml
 	sed -i.bak -e 's|che.webhooks.enabled: .*|che.webhooks.enabled: "false"|g' ./deploy/controller_config.yaml
-	sed -i.bak -e 's|che.default_routing_class: .*|che.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
+	sed -i.bak -e 's|che.workspace.default_routing_class: .*|che.workspace.default_routing_class: "basic"|g' ./deploy/controller_config.yaml
 	sed -i.bak -e 's|cluster.routing_suffix: .*|cluster.routing_suffix: 192.168.99.100.nip.io|g' ./deploy/controller_config.yaml
 	rm ./deploy/controller_config.yaml.bak
 ifeq ($(TOOL),oc)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ make local
 operator-sdk up local --namespace ${NAMESPACE} --enable-delve
 ```
 
+### Controller configuration
+
+Controller behavior can be configured with data from the `che-workspace-controller` config map in the same namespace where controller lives.
+
+For all available configuration properties and their default values, see [pkg/config](https://github.com/che-incubator/che-workspace-operator/tree/master/pkg/config)
+
 ### Remove controller from your K8s/OS Cluster
 To uninstall the controller and associated CRDs, use the Makefile uninstall rule:
 ```bash

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -7,7 +7,9 @@ metadata:
 data:
   cluster.routing_suffix: 192.168.99.100.nip.io
   plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
-  che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
-  cherestapis.image.name: amisevsk/che-rest-apis:v0.0.2
   che.webhooks.enabled: "false"
-  che.default_routing_class: "basic"
+  che.workspace.default_routing_class: "basic"
+  che.workspace.che-api-sidecar.image: amisevsk/che-rest-apis:v0.0.2
+  che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
+  # image pull policy that is applied to all workspace's containers
+  che.workspace.sidecar.image_pull_policy: Always

--- a/deploy/controller_config.yaml
+++ b/deploy/controller_config.yaml
@@ -9,7 +9,7 @@ data:
   plugin.registry.url: http://che-plugin-registry.192.168.99.100.nip.io/v3
   che.webhooks.enabled: "false"
   che.workspace.default_routing_class: "basic"
-  che.workspace.che-api-sidecar.image: amisevsk/che-rest-apis:v0.0.2
+  che.workspace.che_api_sidecar.image: amisevsk/che-rest-apis:v0.0.2
   che.workspace.plugin_broker.artifacts.image: quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0
   # image pull policy that is applied to all workspace's containers
   che.workspace.sidecar.image_pull_policy: Always

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,8 +82,8 @@ func (wc *ControllerConfig) GetPVCStorageClassName() *string {
 	return wc.GetProperty(workspacePVCStorageClassName)
 }
 
-func (wc *ControllerConfig) GetCheRestApisDockerImage() string {
-	return wc.GetPropertyOrDefault(serverImageName, defaultServerImageName)
+func (wc *ControllerConfig) GetCheAPISidecarImage() string {
+	return wc.GetPropertyOrDefault(cheAPISidecarImage, defaultCheAPISidecarImage)
 }
 
 func (wc *ControllerConfig) IsOpenShift() bool {

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,8 +12,6 @@
 
 package config
 
-import "k8s.io/api/admissionregistration/v1beta1"
-
 // Internal constants
 const (
 	// default URL for accessing Che Rest API Emulator from Workspace containers
@@ -99,32 +97,8 @@ const (
 	RestAPIsVolumeName = "che-rest-apis-data"
 )
 
-// constants for webhook
-const (
-	// The address that the webhook will host on
-	WebhookServerHost = "0.0.0.0"
-
-	// The port that the webhook will host on
-	WebhookServerPort = 8443
-
-	// The directory where the certificate can be found by the webhook server
-	WebhookServerCertDir = "/tmp/k8s-webhook-server/serving-certs"
-)
-
-// constants for webhook configuration
-const (
-	// The name of the workspace admission hook
-	MutateWebhookCfgName = "mutate-workspace-admission-hooks"
-
-	// The webhooks path on the server
-	MutateWebhookPath = "/mutate-workspaces"
-
-	// Policy on webhook failure
-	MutateWebhookFailurePolicy = v1beta1.Fail
-)
-
 // constants for workspace controller
 const (
-	// The ide of theia editor in devfile
+	// The IDE of theia editor in devfile
 	TheiaEditorID = "eclipse/che-theia"
 )

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+// The package that is used by components to get configuration.
+//
+// Typically each configuration property has the default value.
+// Default value is supposed to be overridden via config map.
+//
+// There is the following configuration names convention:
+// - words are lower-cased
+// - . is used to separate subcomponents
+// - _ is used to separate words in the component name
+//
+// Examples:
+// che.workspace.plugin_broker.artifacts.image
+// che.workspace.plugin_broker.artifacts.memory_limit
+// Where:
+// che.workspace - indicates that this is going to land to workspace runtime
+// plugin_broker - is a part of workspace
+// artifacts - is a type of plugin broker component
+// memory_limit, image - are just different configuration properties for the same component
+package config

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -21,8 +21,9 @@ const (
 	webhooksEnabled        = "che.webhooks.enabled"
 	defaultWebhooksEnabled = "true"
 
-	serverImageName        = "che.workspace.che-api-sidecar.image"
-	defaultServerImageName = "quay.io/che-incubator/che-workspace-crd-rest-apis:7.1.0"
+	cheAPISidecarImage = "che.workspace.che_api_sidecar.image"
+	// by default that functionality is not available since it's not fully supported
+	defaultCheAPISidecarImage = ""
 
 	sidecarPullPolicy        = "che.workspace.sidecar.image_pull_policy"
 	defaultSidecarPullPolicy = "Always"

--- a/pkg/config/property.go
+++ b/pkg/config/property.go
@@ -13,32 +13,32 @@
 package config
 
 const (
-	serverImageName        = "cherestapis.image.name"
-	defaultServerImageName = "quay.io/che-incubator/che-workspace-crd-rest-apis:7.1.0"
-
-	sidecarPullPolicy        = "sidecar.pull.policy"
-	defaultSidecarPullPolicy = "Always"
-
 	pluginRegistryURL = "plugin.registry.url"
 
 	routingSuffix        = "cluster.routing_suffix"
 	defaultRoutingSuffix = ""
 
+	webhooksEnabled        = "che.webhooks.enabled"
+	defaultWebhooksEnabled = "true"
+
+	serverImageName        = "che.workspace.che-api-sidecar.image"
+	defaultServerImageName = "quay.io/che-incubator/che-workspace-crd-rest-apis:7.1.0"
+
+	sidecarPullPolicy        = "che.workspace.sidecar.image_pull_policy"
+	defaultSidecarPullPolicy = "Always"
+
 	// workspacePVCName config property handles the PVC name that should be created and used for all workspaces within one kubernetes namespace
-	workspacePVCName        = "pvc.name"
+	workspacePVCName        = "che.workspace.pvc.name"
 	defaultWorkspacePVCName = "claim-che-workspace"
 
-	workspacePVCStorageClassName = "pvc.storage_class.name"
+	workspacePVCStorageClassName = "che.workspace_pvc.storage_class.name"
 
 	pluginArtifactsBrokerImage        = "che.workspace.plugin_broker.artifacts.image"
 	defaultPluginArtifactsBrokerImage = "quay.io/eclipse/che-plugin-artifacts-broker:v3.1.0"
 
 	// routingClass defines the default routing class that should be used if user does not specify it explicitly
-	routingClass        = "che.default_routing_class"
+	routingClass        = "che.workspace.default_routing_class"
 	defaultRoutingClass = "basic"
-
-	webhooksEnabled        = "che.webhooks.enabled"
-	defaultWebhooksEnabled = "true"
 
 	workspaceIdleTimeout        = "che.workspace.idle_timeout"
 	defaultWorkspaceIdleTimeout = "15m"

--- a/pkg/controller/workspace/restapis/component.go
+++ b/pkg/controller/workspace/restapis/component.go
@@ -13,7 +13,9 @@
 package restapis
 
 import (
-	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"strings"
+
+	workspacev1alpha1 "github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
 	"github.com/che-incubator/che-workspace-operator/pkg/common"
 	"github.com/che-incubator/che-workspace-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"
@@ -22,9 +24,22 @@ import (
 const cheRestAPIsName = "che-rest-apis"
 const cheRestApisPort = 9999
 
-func GetCheRestApisComponent(workspaceName, workspaceId, namespace string) v1alpha1.ComponentDescription {
+func IsCheRestApisConfigured() bool {
+	return config.ControllerCfg.GetCheAPISidecarImage() != ""
+}
+
+func IsCheRestApisRequired(components []workspacev1alpha1.ComponentSpec) bool {
+	for _, comp := range components {
+		if strings.Contains(comp.Id, config.TheiaEditorID) && comp.Type == workspacev1alpha1.CheEditor {
+			return true
+		}
+	}
+	return false
+}
+
+func GetCheRestApisComponent(workspaceName, workspaceId, namespace string) workspacev1alpha1.ComponentDescription {
 	container := corev1.Container{
-		Image:           config.ControllerCfg.GetCheRestApisDockerImage(),
+		Image:           config.ControllerCfg.GetCheAPISidecarImage(),
 		ImagePullPolicy: corev1.PullPolicy(config.ControllerCfg.GetSidecarPullPolicy()),
 		Name:            cheRestAPIsName,
 		Ports: []corev1.ContainerPort{
@@ -77,14 +92,14 @@ func GetCheRestApisComponent(workspaceName, workspaceId, namespace string) v1alp
 		},
 	}
 
-	return v1alpha1.ComponentDescription{
+	return workspacev1alpha1.ComponentDescription{
 		Name: cheRestAPIsName,
-		PodAdditions: v1alpha1.PodAdditions{
+		PodAdditions: workspacev1alpha1.PodAdditions{
 			Containers: []corev1.Container{container},
 			Volumes:    []corev1.Volume{configmapVolume},
 		},
-		ComponentMetadata: v1alpha1.ComponentMetadata{
-			Containers: map[string]v1alpha1.ContainerDescription{
+		ComponentMetadata: workspacev1alpha1.ComponentMetadata{
+			Containers: map[string]workspacev1alpha1.ContainerDescription{
 				cheRestAPIsName: {
 					Attributes: map[string]string{
 						config.RestApisContainerSourceAttribute: config.RestApisRecipeSourceToolAttribute,
@@ -92,11 +107,11 @@ func GetCheRestApisComponent(workspaceName, workspaceId, namespace string) v1alp
 					Ports: []int{cheRestApisPort},
 				},
 			},
-			Endpoints: []v1alpha1.Endpoint{
+			Endpoints: []workspacev1alpha1.Endpoint{
 				{
-					Attributes: map[v1alpha1.EndpointAttribute]string{
-						v1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE:   "false",
-						v1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE: "tcp",
+					Attributes: map[workspacev1alpha1.EndpointAttribute]string{
+						workspacev1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE:   "false",
+						workspacev1alpha1.PROTOCOL_ENDPOINT_ATTRIBUTE: "tcp",
 					},
 					Name: cheRestAPIsName,
 					Port: int64(cheRestApisPort),


### PR DESCRIPTION
### What does this PR do?
It seems to be a good time to agree on the configuration properties names convention.
In this PR I rename all properties which are supposed to be propagated to workspaces to start with `che.workspace`...
It's a draft and I'm going to review other configurations parts

It also makes Che REST API configuration optional and workspace is failed to start if omit:
![Screenshot_20200601_122958](https://user-images.githubusercontent.com/5887312/83395961-dbefbb80-a403-11ea-98b6-65733b2a0674.png)
![Screenshot_20200601_123016](https://user-images.githubusercontent.com/5887312/83395964-ddb97f00-a403-11ea-8269-36ade1e94208.png)

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/16934

### Is it tested? How?
Not yet
