### PR TITLE
Update workspace annotations/labels to be more inline with org.eclipse.che.workspace

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -34,13 +34,13 @@ const (
 	PVCStorageSize            = "1Gi"
 
 	// WorkspaceIDLabel is label key to store workspace identifier
-	WorkspaceIDLabel = "che.workspace_id"
+	WorkspaceIDLabel = "org.eclipse.che.workspace/id"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
-	WorkspaceEndpointNameAnnotation = "che.workspace.endpoint_name"
+	WorkspaceEndpointNameAnnotation = "org.eclipse.che.workspace/endpoint_name"
 
-	// WorkspaceNameLabel is label key to store workspace identifier
-	WorkspaceNameLabel = "che.workspace_name"
+	// WorkspaceNameLabel is label key to store workspace name
+	WorkspaceNameLabel = "org.eclipse.che.workspace/name"
 
 	// CheOriginalNameLabel is label key to original name
 	CheOriginalNameLabel = "che.original_name"


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR opts for updating the annotations/labels to all be inline with org.eclipse.che.workspace. It's an alternative of https://github.com/eclipse/che/issues/16924 that was suggested and I think it makes more sense to do it this way and align all our annotations/labels at the same time

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16924


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested on openshift 4.5 (thanks cluster bot :wink:). Installed Che with operator and deployed workspace controller with webhooks enabled. Created a workspace on Che using python and it was successfully started and accessible. Also created a cloud shell on workspace controller and everything was started successfully and accessible.  
