### PR TITLE
Make workspace-related objects immutable except by controller

### DIFF
--- a/deploy/k8s/controller.yaml
+++ b/deploy/k8s/controller.yaml
@@ -30,6 +30,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "che-workspace-operator"
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/deploy/os/controller.yaml
+++ b/deploy/os/controller.yaml
@@ -29,6 +29,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "che-workspace-operator"
+            - name: SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
           ports:
             - name: webhook-server
               containerPort: 8443

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -48,6 +48,9 @@ const (
 	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the workspace itself.
 	WorkspaceDiscoverableServiceAnnotation = "io.devfile.workspace/discoverable-service"
+
+	// ControllerServiceAccountNameEnvVar stores the name of the serviceaccount used in the controller.
+	ControllerServiceAccountNameEnvVar = "SERVICE_ACCOUNT_NAME"
 )
 
 // Constants for che-rest-apis

--- a/pkg/controller/workspacerouting/solvers/resolve_endpoints.go
+++ b/pkg/controller/workspacerouting/solvers/resolve_endpoints.go
@@ -33,16 +33,16 @@ func getExposedEndpoints(
 			if endpoint.Attributes[string(workspacev1alpha1.PUBLIC_ENDPOINT_ATTRIBUTE)] != "true" {
 				continue
 			}
-			url, err := resolveURLForEndpoint(endpoint, routingObj)
+			endpointUrl, err := resolveURLForEndpoint(endpoint, routingObj)
 			if err != nil {
 				return nil, false, err
 			}
-			if url == "" {
+			if endpointUrl == "" {
 				ready = false
 			}
 			exposedEndpoints[machineName] = append(exposedEndpoints[machineName], workspacev1alpha1.ExposedEndpoint{
 				Name:       endpoint.Name,
-				Url:        url,
+				Url:        endpointUrl,
 				Attributes: endpoint.Attributes,
 			})
 		}

--- a/pkg/webhook/workspace/handler/handler.go
+++ b/pkg/webhook/workspace/handler/handler.go
@@ -22,9 +22,10 @@ import (
 )
 
 type WebhookHandler struct {
-	ControllerUID string
-	Client        client.Client
-	Decoder       *admission.Decoder
+	ControllerUID    string
+	ControllerSAName string
+	Client           client.Client
+	Decoder          *admission.Decoder
 }
 
 func (h *WebhookHandler) parse(req admission.Request, intoOld runtime.Object, intoNew runtime.Object) error {

--- a/pkg/webhook/workspace/handler/handler.go
+++ b/pkg/webhook/workspace/handler/handler.go
@@ -22,8 +22,9 @@ import (
 )
 
 type WebhookHandler struct {
-	Client  client.Client
-	Decoder *admission.Decoder
+	ControllerUID string
+	Client        client.Client
+	Decoder       *admission.Decoder
 }
 
 func (h *WebhookHandler) parse(req admission.Request, intoOld runtime.Object, intoNew runtime.Object) error {

--- a/pkg/webhook/workspace/handler/immutable.go
+++ b/pkg/webhook/workspace/handler/immutable.go
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package handler
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	devworkspace "github.com/devfile/kubernetes-api/pkg/apis/workspaces/v1alpha1"
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func (h *WebhookHandler) HandleImmutableMutate(_ context.Context, req admission.Request) admission.Response {
+	oldObj := &unstructured.Unstructured{}
+	newObj := &unstructured.Unstructured{}
+	err := h.parse(req, oldObj, newObj)
+	if err != nil {
+		return admission.Denied(err.Error())
+	}
+	allowed, msg := h.handleImmutableObj(oldObj, newObj, req.UserInfo.UID)
+	if allowed {
+		return admission.Allowed(msg)
+	}
+	return admission.Denied(msg)
+}
+
+func (h *WebhookHandler) HandleImmutableCreate(_ context.Context, req admission.Request) admission.Response {
+	if req.UserInfo.UID != h.ControllerUID {
+		return admission.Denied("Only the workspace controller can create workspace objects.")
+	}
+	return admission.Allowed("Object created by workspace controller service account.")
+}
+
+func (h *WebhookHandler) handleImmutableWorkspace(oldWksp, newWksp *devworkspace.DevWorkspace, uid string) (allowed bool, msg string) {
+	creatorUID := oldWksp.Labels[config.WorkspaceCreatorLabel]
+	if uid == creatorUID || uid == h.ControllerUID {
+		return true, "immutable workspace is updated by owner or controller"
+	}
+	if cmp.Equal(oldWksp, newWksp, StopStartDiffOption[:]...) {
+		return true, "immutable workspace is started/stopped"
+	}
+	return false, fmt.Sprintf("workspace '%s' is immutable and can only be modified by its creator.", oldWksp.Name)
+}
+
+func (h *WebhookHandler) handleImmutableObj(oldObj, newObj runtime.Object, uid string) (allowed bool, msg string) {
+	if uid == h.ControllerUID {
+		return true, ""
+	}
+	if reflect.DeepEqual(oldObj, newObj) {
+		return true, ""
+	}
+	return false, "object is owned by workspace and cannot be updated."
+}

--- a/pkg/webhook/workspace/handler/kind.go
+++ b/pkg/webhook/workspace/handler/kind.go
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package handler
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+var (
+	V1alpha1WorkspaceKind        = metav1.GroupVersionKind{Kind: "Workspace", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
+	V1alpha1WorkspaceRoutingKind = metav1.GroupVersionKind{Kind: "WorkspaceRouting", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
+	V1alpha1ComponentKind        = metav1.GroupVersionKind{Kind: "Component", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
+
+	AppsV1DeploymentKind = metav1.GroupVersionKind{Kind: "Deployment", Group: "apps", Version: "v1"}
+	V1PodKind            = metav1.GroupVersionKind{Kind: "Pod", Group: "", Version: "v1"}
+	V1ServiceKind        = metav1.GroupVersionKind{Kind: "Service", Group: "", Version: "v1"}
+	V1beta1IngressKind   = metav1.GroupVersionKind{Kind: "Ingress", Group: "extensions", Version: "v1beta1"}
+	V1RouteKind          = metav1.GroupVersionKind{Kind: "Route", Group: "route.openshift.io", Version: "v1"}
+)

--- a/pkg/webhook/workspace/handler/kind.go
+++ b/pkg/webhook/workspace/handler/kind.go
@@ -14,7 +14,7 @@ package handler
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 var (
-	V1alpha1WorkspaceKind        = metav1.GroupVersionKind{Kind: "Workspace", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
+	V1alpha1DevWorkspaceKind     = metav1.GroupVersionKind{Kind: "DevWorkspace", Group: "workspace.devfile.io", Version: "v1alpha1"}
 	V1alpha1WorkspaceRoutingKind = metav1.GroupVersionKind{Kind: "WorkspaceRouting", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
 	V1alpha1ComponentKind        = metav1.GroupVersionKind{Kind: "Component", Group: "workspace.che.eclipse.org", Version: "v1alpha1"}
 

--- a/pkg/webhook/workspace/handler/workspace.go
+++ b/pkg/webhook/workspace/handler/workspace.go
@@ -23,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-var V1alpha1DevWorkspaceKind = metav1.GroupVersionKind{Kind: "DevWorkspace", Group: "workspace.devfile.io", Version: "v1alpha1"}
-
 // StopStartDiffOption is comparing options that should be used to check if there is no other changes except changing started
 var StopStartDiffOption = []cmp.Option{
 	// field managed by cluster and should be ignored while comparing

--- a/pkg/webhook/workspace/mutate.go
+++ b/pkg/webhook/workspace/mutate.go
@@ -27,8 +27,8 @@ type ResourcesMutator struct {
 	*handler.WebhookHandler
 }
 
-func NewResourcesMutator() *ResourcesMutator {
-	return &ResourcesMutator{&handler.WebhookHandler{}}
+func NewResourcesMutator(controllerUID string) *ResourcesMutator {
+	return &ResourcesMutator{&handler.WebhookHandler{ControllerUID: controllerUID}}
 }
 
 // ResourcesMutator verify if operation is a valid from Workspace controller perspective
@@ -43,6 +43,10 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnCreate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnCreate(ctx, req)
+			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
+				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
+
+				return m.HandleImmutableCreate(ctx, req)
 			}
 		}
 	case v1beta1.Update:
@@ -54,6 +58,10 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnUpdate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnUpdate(ctx, req)
+			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
+				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
+
+				return m.HandleImmutableMutate(ctx, req)
 			}
 		}
 	}

--- a/pkg/webhook/workspace/mutate.go
+++ b/pkg/webhook/workspace/mutate.go
@@ -43,7 +43,7 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnCreate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnCreate(ctx, req)
-			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
+			case handler.V1ServiceKind, handler.V1beta1IngressKind,
 				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
 
 				return m.HandleImmutableCreate(ctx, req)

--- a/pkg/webhook/workspace/mutate.go
+++ b/pkg/webhook/workspace/mutate.go
@@ -27,8 +27,8 @@ type ResourcesMutator struct {
 	*handler.WebhookHandler
 }
 
-func NewResourcesMutator(controllerUID string) *ResourcesMutator {
-	return &ResourcesMutator{&handler.WebhookHandler{ControllerUID: controllerUID}}
+func NewResourcesMutator(controllerUID, controllerSAName string) *ResourcesMutator {
+	return &ResourcesMutator{&handler.WebhookHandler{ControllerUID: controllerUID, ControllerSAName: controllerSAName}}
 }
 
 // ResourcesMutator verify if operation is a valid from Workspace controller perspective
@@ -43,7 +43,7 @@ func (m *ResourcesMutator) Handle(ctx context.Context, req admission.Request) ad
 				return m.MutatePodOnCreate(ctx, req)
 			case handler.AppsV1DeploymentKind:
 				return m.MutateDeploymentOnCreate(ctx, req)
-			case handler.V1ServiceKind, handler.V1beta1IngressKind,
+			case handler.V1ServiceKind, handler.V1beta1IngressKind, handler.V1RouteKind,
 				handler.V1alpha1ComponentKind, handler.V1alpha1WorkspaceRoutingKind:
 
 				return m.HandleImmutableCreate(ctx, req)

--- a/pkg/webhook/workspace/mutating_cfg.go
+++ b/pkg/webhook/workspace/mutating_cfg.go
@@ -110,16 +110,17 @@ func buildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 			},
 		},
 	}
-	if config.ControllerCfg.IsOpenShift() {
-		workspaceObjMutateWebhook.Rules = append(workspaceObjMutateWebhook.Rules, v1beta1.RuleWithOperations{
-			Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
-			Rule: v1beta1.Rule{
-				APIGroups:   []string{"route.openshift.io"},
-				APIVersions: []string{"v1"},
-				Resources:   []string{"routes"},
-			},
-		})
-	}
+	// TODO: Routes do not get UserInfo.UID filled in webhooks for some reason
+	// if config.ControllerCfg.IsOpenShift() {
+	// 	workspaceObjMutateWebhook.Rules = append(workspaceObjMutateWebhook.Rules, v1beta1.RuleWithOperations{
+	// 		Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+	// 		Rule: v1beta1.Rule{
+	// 			APIGroups:   []string{"route.openshift.io"},
+	// 			APIVersions: []string{"v1"},
+	// 			Resources:   []string{"routes"},
+	// 		},
+	// 	})
+	// }
 
 	return &v1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/webhook/workspace/mutating_cfg.go
+++ b/pkg/webhook/workspace/mutating_cfg.go
@@ -110,17 +110,18 @@ func buildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfigurati
 			},
 		},
 	}
-	// TODO: Routes do not get UserInfo.UID filled in webhooks for some reason
-	// if config.ControllerCfg.IsOpenShift() {
-	// 	workspaceObjMutateWebhook.Rules = append(workspaceObjMutateWebhook.Rules, v1beta1.RuleWithOperations{
-	// 		Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
-	// 		Rule: v1beta1.Rule{
-	// 			APIGroups:   []string{"route.openshift.io"},
-	// 			APIVersions: []string{"v1"},
-	// 			Resources:   []string{"routes"},
-	// 		},
-	// 	})
-	// }
+	// n.b. Routes do not get UserInfo.UID filled in webhooks for some reason
+	// ref: https://github.com/eclipse/che/issues/17114
+	if config.ControllerCfg.IsOpenShift() {
+		workspaceObjMutateWebhook.Rules = append(workspaceObjMutateWebhook.Rules, v1beta1.RuleWithOperations{
+			Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+			Rule: v1beta1.Rule{
+				APIGroups:   []string{"route.openshift.io"},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"routes"},
+			},
+		})
+	}
 
 	return &v1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/webhook/workspace/validate.go
+++ b/pkg/webhook/workspace/validate.go
@@ -27,8 +27,8 @@ type ResourcesValidator struct {
 	*handler.WebhookHandler
 }
 
-func NewResourcesValidator(controllerUID string) *ResourcesValidator {
-	return &ResourcesValidator{&handler.WebhookHandler{ControllerUID: controllerUID}}
+func NewResourcesValidator(controllerUID, controllerSAName string) *ResourcesValidator {
+	return &ResourcesValidator{&handler.WebhookHandler{ControllerUID: controllerUID, ControllerSAName: controllerSAName}}
 }
 
 func (v *ResourcesValidator) Handle(ctx context.Context, req admission.Request) admission.Response {

--- a/pkg/webhook/workspace/validate.go
+++ b/pkg/webhook/workspace/validate.go
@@ -27,8 +27,8 @@ type ResourcesValidator struct {
 	*handler.WebhookHandler
 }
 
-func NewResourcesValidator() *ResourcesValidator {
-	return &ResourcesValidator{&handler.WebhookHandler{}}
+func NewResourcesValidator(controllerUID string) *ResourcesValidator {
+	return &ResourcesValidator{&handler.WebhookHandler{ControllerUID: controllerUID}}
 }
 
 func (v *ResourcesValidator) Handle(ctx context.Context, req admission.Request) admission.Response {


### PR DESCRIPTION
### What does this PR do?
- Make objects owned by workspace (e.g. routes, services) immutable except by workspace controller 
- Make immutable workspaces editable by creator and controller.

### What issues does this PR fix or reference?
Resolves https://github.com/eclipse/che/issues/16943

### Is it tested? How?
Tested on `crc`:
1. Create a workspace
2. Try to edit service, route, ingress, pod, deployment -> denied 
3. Set workspace to immutable
4. Edit workspace as owner -> changes are still propagated (controller can update resources)
5. Login as another user, edit workspace -> denied (not owner)
