### PR TITLE
Revert changes to label used for workspace ID

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -30,7 +30,7 @@ const (
 	PVCStorageSize            = "1Gi"
 
 	// WorkspaceIDLabel is label key to store workspace identifier
-	WorkspaceIDLabel = "org.eclipse.che.workspace/id"
+	WorkspaceIDLabel = "che.workspace_id"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
 	WorkspaceEndpointNameAnnotation = "org.eclipse.che.workspace/endpoint_name"


### PR DESCRIPTION
### What does this PR do?
The machine-exec plugin expects the workspace pod to be labelled with
```
    che.workspace_id
```
Changing this label name causes pod resolution to break in the machine-exec plugin.

We should reapply this change after changing machine-exec to accomodate the alternate label.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17099
