### PR TITLE
Make sure webhooks reference the correct service

### DIFF
--- a/pkg/webhook/workspace/mutating_cfg.go
+++ b/pkg/webhook/workspace/mutating_cfg.go
@@ -24,7 +24,7 @@ const (
 	mutateWebhookFailurePolicy = v1beta1.Fail
 )
 
-func buildMutateWebhookCfg() *v1beta1.MutatingWebhookConfiguration {
+func buildMutateWebhookCfg(namespace string) *v1beta1.MutatingWebhookConfiguration {
 	mutateWebhookFailurePolicy := mutateWebhookFailurePolicy
 	mutateWebhookPath := mutateWebhookPath
 	labelExistsOp := metav1.LabelSelectorOpExists
@@ -40,7 +40,7 @@ func buildMutateWebhookCfg() *v1beta1.MutatingWebhookConfiguration {
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
 						Name:      "workspace-controller",
-						Namespace: "che-workspace-controller",
+						Namespace: namespace,
 						Path:      &mutateWebhookPath,
 					},
 					CABundle: server.CABundle,
@@ -62,7 +62,7 @@ func buildMutateWebhookCfg() *v1beta1.MutatingWebhookConfiguration {
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
 						Name:      "workspace-controller",
-						Namespace: "che-workspace-controller",
+						Namespace: namespace,
 						Path:      &mutateWebhookPath,
 					},
 					CABundle: server.CABundle,

--- a/pkg/webhook/workspace/validating_cfg.go
+++ b/pkg/webhook/workspace/validating_cfg.go
@@ -23,7 +23,7 @@ const (
 	validateWebhookFailurePolicy = v1beta1.Fail
 )
 
-func buildValidatingWebhookCfg() *v1beta1.ValidatingWebhookConfiguration {
+func buildValidatingWebhookCfg(namespace string) *v1beta1.ValidatingWebhookConfiguration {
 	validateWebhookFailurePolicy := validateWebhookFailurePolicy
 	validateWebhookPath := validateWebhookPath
 	return &v1beta1.ValidatingWebhookConfiguration{
@@ -37,7 +37,7 @@ func buildValidatingWebhookCfg() *v1beta1.ValidatingWebhookConfiguration {
 				ClientConfig: v1beta1.WebhookClientConfig{
 					Service: &v1beta1.ServiceReference{
 						Name:      "workspace-controller",
-						Namespace: "che-workspace-controller",
+						Namespace: namespace,
 						Path:      &validateWebhookPath,
 					},
 					CABundle: server.CABundle,


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes sure that the webhooks reference the correct service when the operator is deployed in a different namespace than che-workspace-controller

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17098

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
Tested on CRC with webhooks enabled
