### PR TITLE
Rename labels and annotations base to io.devfile.workspace

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -33,20 +33,21 @@ const (
 	WorkspaceIDLabel = "che.workspace_id"
 
 	// WorkspaceEndpointNameAnnotation is the annotation key for storing an endpoint's name from the devfile representation
-	WorkspaceEndpointNameAnnotation = "org.eclipse.che.workspace/endpoint_name"
+	WorkspaceEndpointNameAnnotation = "io.devfile.workspace/endpoint_name"
 
 	// WorkspaceNameLabel is label key to store workspace name
-	WorkspaceNameLabel = "org.eclipse.che.workspace/name"
+	WorkspaceNameLabel = "io.devfile.workspace/name"
 
 	// WorkspaceCreatorLabel is the label key for storing the UID of the user who created the workspace
-	WorkspaceCreatorLabel = "org.eclipse.che.workspace/creator"
+	WorkspaceCreatorLabel = "io.devfile.workspace/creator"
 
-	// WorkspaceImmutableAnnotation marks a workspace as 'immutable' if 'true'
-	WorkspaceImmutableAnnotation = "org.eclipse.che.workspace/immutable"
+	// WorkspaceImmutableAnnotation marks the intention that workspace access is restricted to only the creator; setting this
+	// annotation will cause workspace start to fail if webhooks are disabled.
+	WorkspaceImmutableAnnotation = "io.devfile.workspace/restricted-access"
 
 	// WorkspaceDiscoverableServiceAnnotation marks a service in a workspace as created for a discoverable endpoint,
 	// as opposed to a service created to support the workspace itself.
-	WorkspaceDiscoverableServiceAnnotation = "org.eclipse.che.workspace/discoverable-service"
+	WorkspaceDiscoverableServiceAnnotation = "io.devfile.workspace/discoverable-service"
 )
 
 // Constants for che-rest-apis

--- a/samples/command-line-terminal-dev.yaml
+++ b/samples/command-line-terminal-dev.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     # it's important to make workspace immutable to make sure nobody with right access
     # won't set custom editor to steal creator's token
-    org.eclipse.che.workspace/immutable: "true"
+    io.devfile.workspace/restricted-access: "true"
   labels:
     # it's a label OpenShift console uses a flag to mark terminal's workspaces
     console.openshift.io/cloudshell: "true"

--- a/samples/command-line-terminal.yaml
+++ b/samples/command-line-terminal.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     # it's important to make workspace immutable to make sure nobody with right access
     # won't set custom editor to steal creator's token
-    org.eclipse.che.workspace/immutable: "true"
+    io.devfile.workspace/restricted-access: "true"
   labels:
     # it's a label OpenShift console uses a flag to mark terminal's workspaces
     console.openshift.io/cloudshell: "true"


### PR DESCRIPTION
### What does this PR do?
Rename labels and annotations from
```
org.eclipse.che.workspace/*
```
to 
```
io.devfile.workspace/*
```
and renames `immutable` annotation to `restricted-access` to match semantics coming from https://github.com/che-incubator/che-workspace-operator/pull/89/